### PR TITLE
Only check links in modified markdown files

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           use-quiet-mode: 'yes'
           use-verbose-mode: 'yes'
+          check-modified-files-only: 'yes'
           config-file: './mlc_config.json'
         continue-on-error: true
         id: md-link-check


### PR DESCRIPTION
To improve the speed and potential reduce the error rate for link-checking the tool can be restricted to only check modified files.

https://github.com/gaurav-nelson/github-action-markdown-link-check#check-only-modified-files-in-a-pull-request

It would make sense to introduce another action that is run daily to check all links across a repo to catch links that have become deprecated.