### PR TITLE
Update mlc_config.json to ignore nuget.org

### DIFF
--- a/.github/utilities/md-check/mlc_config.json
+++ b/.github/utilities/md-check/mlc_config.json
@@ -1,7 +1,8 @@
 {
 	"ignorePatterns": [
 		{
-			"pattern": "^https://github.com"
+			"pattern": "^https://github.com",
+			"pattern": "^https://nuget.org"
 		}
 	]
 }


### PR DESCRIPTION
Ignore links to nuget.org

Some sites might block our link check because they consider the request originating from a bot. This breaks our workflow.

This is being explained in this issue: 
https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/102#issuecomment-776325241