### PR TITLE
Fix input param in `dotnet-create-webapi-artifact` and `dotnet-create-function-artifact` workflows

### DIFF
--- a/.github/workflows/dotnet-create-function-artifact.yml
+++ b/.github/workflows/dotnet-create-function-artifact.yml
@@ -32,11 +32,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
-              
-      - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
+
+      - name: Setup .NET ${{ inputs.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: ${{ inputs.DOTNET_VERSION }}
 
       - name: Build project
         shell: bash

--- a/.github/workflows/dotnet-create-webapi-artifact.yml
+++ b/.github/workflows/dotnet-create-webapi-artifact.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@master
 
-      - name: Setup .NET ${{ input.DOTNET_VERSION }} environment
+      - name: Setup .NET ${{ inputs.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ input.DOTNET_VERSION }}
+          dotnet-version: ${{ inputs.DOTNET_VERSION }}
 
       - name: Build/publish project
         shell: bash

--- a/.github/workflows/dotnet-create-webapi-artifact.yml
+++ b/.github/workflows/dotnet-create-webapi-artifact.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@master
 
-      - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
+      - name: Setup .NET ${{ input.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: ${{ input.DOTNET_VERSION }}
 
       - name: Build/publish project
         shell: bash


### PR DESCRIPTION
* Fix input param in `dotnet-create-webapi-artifact` workflow because the `DOTNET_VERSION` input param is not set ([pipeline error](https://github.com/Energinet-DataHub/greenforce-frontend/runs/4883991007?check_suite_focus=true))
* Fix input param in `dotnet-create-function-artifact` workflow because the `DOTNET_VERSION` input param is not set

