### PR TITLE
Cosmos db emulator

### DIFF
--- a/.github/workflows/dotnet-solution-ci.yml
+++ b/.github/workflows/dotnet-solution-ci.yml
@@ -92,7 +92,7 @@ jobs:
         if: ${{ inputs.USE_COSMOS_DB_EMULATOR == true }}
         shell: pwsh
         run: |
-          Write-Host "Start Cosmos DB Emulator"
+          Write-Host "Start Cosmos DB Emulator..."
           Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
           Start-CosmosDbEmulator
           $status = Get-CosmosDbEmulatorStatus

--- a/.github/workflows/dotnet-solution-ci.yml
+++ b/.github/workflows/dotnet-solution-ci.yml
@@ -90,7 +90,11 @@ jobs:
 
       - name: Setup Azure Cosmos DB Emulator
         if: ${{ inputs.USE_COSMOS_DB_EMULATOR == true }}
-        uses: southpolesteve/cosmos-emulator-github-action@v1
+        shell: pwsh
+        run: |
+          Write-Host "Start Cosmos DB Emulator"
+          Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
+          Start-CosmosDbEmulator
 
       - name: Install Azurite v${{ env.AZURITE_VERSION }}
         if: ${{ inputs.USE_AZURITE == true }}

--- a/.github/workflows/dotnet-solution-ci.yml
+++ b/.github/workflows/dotnet-solution-ci.yml
@@ -95,6 +95,12 @@ jobs:
           Write-Host "Start Cosmos DB Emulator"
           Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
           Start-CosmosDbEmulator
+          $status = Get-CosmosDbEmulatorStatus
+          if ($status -ne 'Running')
+          {
+            throw "Cosmos DB Emulator did not start within expected time."
+          }
+          Write-Host "Cosmos DB Emulator is running."
 
       - name: Install Azurite v${{ env.AZURITE_VERSION }}
         if: ${{ inputs.USE_AZURITE == true }}

--- a/.github/workflows/dotnet-solution-ci.yml
+++ b/.github/workflows/dotnet-solution-ci.yml
@@ -95,12 +95,6 @@ jobs:
           Write-Host "Start Cosmos DB Emulator..."
           Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
           Start-CosmosDbEmulator
-          $status = Get-CosmosDbEmulatorStatus
-          if ($status -ne 'Running')
-          {
-            throw "Cosmos DB Emulator did not start within expected time."
-          }
-          Write-Host "Cosmos DB Emulator is running."
 
       - name: Install Azurite v${{ env.AZURITE_VERSION }}
         if: ${{ inputs.USE_AZURITE == true }}


### PR DESCRIPTION
Ensure the pipeline fails if the Cosmos DB emulator does not start.

Currently, if the Cosmos DB emulator fails, the pipeline continues and we don't discover the issues until all tests fails in the pipeline - which can be 10 minutes later. To save time, fail fast.