### PR TITLE
Fail databricks unit test step when unit tests fail

### DIFF
--- a/.github/actions/databricks-unit-test/entrypoint.sh
+++ b/.github/actions/databricks-unit-test/entrypoint.sh
@@ -14,14 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Exit immediately with failure status if any command fails
+set -eo pipefail
+
 cd ./source/databricks/tests/
 #Build wheel
 python ../setup.py install
 # python coverage-threshold install
 pip install coverage-threshold delta-spark
 coverage run --branch -m pytest .
-# Exit with failure status if tests failed
-if [ $? -ne 0 ]; then exit 1; fi
 # Create data for threshold evaluation
 coverage json
 # Create human reader friendly HTML report

--- a/.github/actions/databricks-unit-test/entrypoint.sh
+++ b/.github/actions/databricks-unit-test/entrypoint.sh
@@ -20,6 +20,8 @@ python ../setup.py install
 # python coverage-threshold install
 pip install coverage-threshold delta-spark
 coverage run --branch -m pytest .
+# Exit with failure status if tests failed
+if [ $? -ne 0 ]; then exit 1; fi
 # Create data for threshold evaluation
 coverage json
 # Create human reader friendly HTML report

--- a/.github/workflows/python-ci-test-and-coverage.yml
+++ b/.github/workflows/python-ci-test-and-coverage.yml
@@ -44,7 +44,7 @@ jobs:
           ignore: ${{ inputs.IGNORE_ERRORS_AND_WARNING_FLAKE8 }}
 
       - name: Run unit tests
-        uses: Energinet-DataHub/.github/.github/actions/databricks-unit-test@5.0.3
+        uses: Energinet-DataHub/.github/.github/actions/databricks-unit-test@main
 
       - name: Upload test report
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Currently, Databricks CI job doesn't fail when a unit test fails. This allows pull-requests to be merged despite the execution of python unit tests failing in PR gate. Example [here](https://github.com/Energinet-DataHub/geh-timeseries/runs/5676987942?check_suite_focus=true).