### PR TITLE
Fix databricks unit test action

### DIFF
--- a/.github/actions/databricks-unit-test/entrypoint.sh
+++ b/.github/actions/databricks-unit-test/entrypoint.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Exit immediately with failure status if any command fails
-set -eo pipefail
+set -e
 
 cd ./source/databricks/tests/
 #Build wheel


### PR DESCRIPTION
Option `-o pipefail` of the `set` command is supported in `/bin/bash` but not in the default Docker shell `/bin/sh`.
There are currently no pipes so skipping this option is the simplest fix.