### PR TITLE
Update python-ci-test-and-coverage.yml

### DIFF
--- a/.github/workflows/python-ci-test-and-coverage.yml
+++ b/.github/workflows/python-ci-test-and-coverage.yml
@@ -41,7 +41,7 @@ jobs:
           ignore: ${{ inputs.IGNORE_ERRORS_AND_WARNING_FLAKE8 }}
 
       - name: Run unit tests
-        uses: ./.github/actions/databricks-unit-test
+        uses: ./.github/actions/databricks-unit-test@7.0.0
 
       - name: Upload test report
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
If workflow actions are not bound to specific versions, then older versions of workflows will break when breaking changes are introduced in the actions.

@dstsyst , @Renetnielsen , @djorgensendk , this is probably something you'd like to pay attention to when reviewing future PRs.