### PR TITLE
Lowercase NuGet API url

### DIFF
--- a/.github/actions/nuget-assert-release-version/action.yml
+++ b/.github/actions/nuget-assert-release-version/action.yml
@@ -56,7 +56,7 @@ runs:
             {
                 Write-Host "Check that '$packageId' version '$packageVersion' does not exist."
 
-                $response = Invoke-RestMethod -Uri $url -Method $method
+                $response = Invoke-RestMethod -Uri $url.ToLower() -Method $method
 
                 Write-Host "::error::'$packageId' version '$packageVersion' exists. You need to create a newer version."
                 $hasError = $true


### PR DESCRIPTION
We must ensure the URL used when calling the NuGet API is all lowercase.