### PR TITLE
Temporarily disable integration test in CI

### DIFF
--- a/.github/workflows/dotnet-solution-ci.yml
+++ b/.github/workflows/dotnet-solution-ci.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Run tests and publish report
         run: |
           dotnet tool install --tool-path ./temp/reportgenerator dotnet-reportgenerator-globaltool
-          dotnet test ${{ inputs.SOLUTION_FILE_PATH }} --no-build --configuration ${{ env.BUILD_CONFIGURATION }} --verbosity normal --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
+          dotnet test ${{ inputs.SOLUTION_FILE_PATH }} --filter Category=UnitTest --no-build --configuration ${{ env.BUILD_CONFIGURATION }} --verbosity normal --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
 
       - name: Upload coverage to CodeCov
         uses: codecov/codecov-action@v2


### PR DESCRIPTION
As a temporary solution to overcome an issue running integration tests using Azure resources, we have decided to disable integration tests in the CI pipeline.

This pull request must be followed by pull requests in each domain to use the new workflow.

And last but not least, this is temporary! and must be followed up by a new pull request with a solution to the issue of running integration tests using Azure resources.