### PR TITLE
extended release related workflows

### DIFF
--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -20,6 +20,10 @@ on:
         required: true
         type: string
         description: 'Path to local repository, syntax: {owner}/{repo}'
+      RELEASE_NAME_PREFIX:
+        required: false
+        type: string
+        description: 'Use this variable if you want to prefix the release name, for instance with multiple releases from same repository'
     secrets:
       PAT_TOKEN:
         required: true
@@ -31,7 +35,7 @@ jobs:
     env:
       RELEASE_FOLDER_PATH: ${{ github.workspace }}/release
       REPO_FOLDER_PATH: ${{ github.workspace }}/remote_repo
-      RELEASE_VERSION: ${{ github.event.pull_request.number }}
+      RELEASE_VERSION: ${{ inputs.RELEASE_NAME_PREFIX }}${{ github.event.pull_request.number }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -39,10 +43,19 @@ jobs:
           repository: ${{ inputs.CALLER_REPOSITORY_PATH }}
           path: ${{ env.REPO_FOLDER_PATH }}
 
-      - name: Publish release content
+      - name: Publish release content with multiple releases from same content
+        if: ${{ env.RELEASE_NAME_PREFIX != '' }}
         uses: ./remote_repo/.github/actions/publish-release-contents
         with:
-          RELEASE_FOLDER_PATH: ${{ env.RELEASE_FOLDER_PATH }}
+          RELEASE_FOLDER_PATH: ${{ env.RELEASE_FOLDER_PATH }}
+          REPO_FOLDER_PATH: ${{ env.REPO_FOLDER_PATH }}
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+
+      - name: Publish release content without multiple releases from same content
+        if: ${{ env.RELEASE_NAME_PREFIX == '' }}
+        uses: ./remote_repo/.github/actions/publish-release-contents
+        with:
+          RELEASE_FOLDER_PATH: ${{ env.RELEASE_FOLDER_PATH }}
           REPO_FOLDER_PATH: ${{ env.REPO_FOLDER_PATH }}
 
       - name: Zip artifact

--- a/.github/workflows/dispatch-deployment-request.yml
+++ b/.github/workflows/dispatch-deployment-request.yml
@@ -24,6 +24,14 @@ on:
         required: true
         description: 'Path to local repository, syntax: {owner}/{repo}'
         type: string
+      RELEASE_NAME_PREFIX:
+        required: false
+        type: string
+        description: 'Use this variable if you want to prefix the release name'
+      CUSTOM_EVENT_TYPE:
+        required: false
+        type: string
+        description: 'Use this variable if you want to override the current event naming convention'
     secrets:
       PAT_TOKEN:
         required: true
@@ -37,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REMOTE_REPO_FOLDER_PATH: '${{ github.workspace }}/remote_repo'
-      EVENT_TYPE: '${{ inputs.CALLER_REPOSITORY_NAME }}-deployment-request'
+      EVENT_TYPE: '${{ inputs.CUSTOM_EVENT_TYPE || inputs.CALLER_REPOSITORY_NAME }}-deployment-request'
     steps:
       - name: Find associated pull request
         uses: jwalton/gh-find-current-pr@v1
@@ -52,7 +60,7 @@ jobs:
       - name: Set RELEASE_VERSION
         shell: bash
         run: |
-          echo "RELEASE_VERSION=${{ steps.find_pull_request.outputs.pr }}" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=${{ inputs.RELEASE_NAME_PREFIX }}${{ steps.find_pull_request.outputs.pr }}" >> $GITHUB_ENV
 
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,6 +19,11 @@ on:
       PAT_TOKEN:
         required: true
         description: 'Personal access token'
+    inputs:
+      RELEASE_NAME_PREFIX:
+        required: false
+        type: string
+        description: 'Use this variable if you want to prefix the release name'
 
 jobs:
   publish_release:
@@ -34,7 +39,7 @@ jobs:
         if: steps.find_pull_request.outputs.pr != ''
         shell: bash
         run: |
-          echo "RELEASE_VERSION=${{ steps.find_pull_request.outputs.pr }}" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=${{ inputs.RELEASE_NAME_PREFIX }}${{ steps.find_pull_request.outputs.pr }}" >> $GITHUB_ENV
 
       - name: Publish release
         if: steps.find_pull_request.outputs.pr != ''


### PR DESCRIPTION
Extended all workflows related to creating and releasing releases with the possibility to prefix the release version (Currently we take PR number).
This will work better for repos where we want a certain prefix in front.
For instance in the greenforce-frontend where they have many different releases.

I tested that the old ones still work (Triggered the events using the new workflows but without providing the new values): 

CD: https://github.com/Energinet-DataHub/geh-shared-resources/actions/runs/2881162977
CI: https://github.com/Energinet-DataHub/geh-shared-resources/actions/runs/2881120347
DH3: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/2881166610


Release following old pattern: https://github.com/Energinet-DataHub/geh-shared-resources/releases/tag/240