### PR TITLE
remove lineendings in chart-info action

### DIFF
--- a/.github/actions/chart-info/action.yaml
+++ b/.github/actions/chart-info/action.yaml
@@ -28,7 +28,7 @@ runs:
       id: chart
       shell: bash
       run: |
-        NAME=$(grep ^"name: " ${{ inputs.chart-folder }}/Chart.yaml | cut -f2 -d' ')
+        NAME=$(grep ^"name: " ${{ inputs.chart-folder }}/Chart.yaml | cut -f2 -d' ' | tr -d '\r')
         echo ::set-output name=name::$NAME
         if [ ${{ inputs.include-image-name }} = "true" ]; then
           echo ::set-output name=tag-name::$NAME-${{ inputs.chart-version }}


### PR DESCRIPTION
Previously chart-info action would fail when a windows the Chart.yaml uses CRLF lineendings. This is fixed my removing them. 