### PR TITLE
Added Scala files to license check

### DIFF
--- a/.github/utilities/license-check/.licenserc.json
+++ b/.github/utilities/license-check/.licenserc.json
@@ -93,5 +93,20 @@
     "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
     "# See the License for the specific language governing permissions and",
     "# limitations under the License."
+  ],
+  "**/*.scala": [
+    "// Copyright 2020 Energinet DataHub A/S",
+    "//",
+    "// Licensed under the Apache License, Version 2.0 (the \"License2\");",
+    "// you may not use this file except in compliance with the License.",
+    "// You may obtain a copy of the License at",
+    "//",
+    "//     http://www.apache.org/licenses/LICENSE-2.0",
+    "//",
+    "// Unless required by applicable law or agreed to in writing, software",
+    "// distributed under the License is distributed on an \"AS IS\" BASIS,",
+    "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+    "// See the License for the specific language governing permissions and",
+    "// limitations under the License."
   ]
 }


### PR DESCRIPTION
We have some databricks notebooks written i scala, and need license check on .scala files