### PR TITLE
Bump .NET version used on runners

### DIFF
--- a/.github/actions/dotnet-setup-and-tools/action.yml
+++ b/.github/actions/dotnet-setup-and-tools/action.yml
@@ -19,7 +19,7 @@ inputs:
   DOTNET_VERSION:
     description: 'Install specified .NET Core SDK version'
     required: false
-    default: '6.0'
+    default: '6.0.400' # Reset to '6.0' when GitHub runners are updated to use latest 6.0
     type: 'string'
   # Cosmos DB emulator
   USE_COSMOS_DB_EMULATOR:

--- a/.github/workflows/dotnet-solution-ci.yml
+++ b/.github/workflows/dotnet-solution-ci.yml
@@ -23,7 +23,7 @@ on:
       DOTNET_VERSION:
         description: 'Install specified .NET Core SDK version'
         required: false
-        default: '6.0'
+        default: '6.0.400' # Reset to '6.0' when GitHub runners are updated to use latest 6.0
         type: 'string'
       OPERATING_SYSTEM:
         required: false

--- a/.github/workflows/sonarcloud-dotnet.yml
+++ b/.github/workflows/sonarcloud-dotnet.yml
@@ -23,7 +23,7 @@ on:
       DOTNET_VERSION:
         description: 'Install specified .NET Core SDK version'
         required: false
-        default: '6.0'
+        default: '6.0.400' # Reset to '6.0' when GitHub runners are updated to use latest 6.0
         type: 'string'
       SONAR_CLOUD_ORGANIZATION:
         required: true
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
-      
+
       - name: Setup .NET ${{ inputs.DOTNET_VERSION }}
         uses: actions/setup-dotnet@v2
         with:


### PR DESCRIPTION
GitHub runners is currently using 6.0.400 while the latest .NET SDK is 6.0.401.

After merge to main we will create release 8.2.0 and move the v8 tag to this.

Tested action "Setup dotnet and tools" in run: https://github.com/Energinet-DataHub/geh-core/actions/runs/3059879196