### PR TITLE
Added missing default value to publish release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,6 +24,7 @@ on:
         required: false
         type: string
         description: 'Use this variable if you want to prefix the release name'
+        default: 'dotnet'
 
 jobs:
   publish_release:


### PR DESCRIPTION
Currently Releases is not being published, due to them changing name to dotnet.
By adding this default value, it will start working again