### PR TITLE
Create Dotnet coverage reports correctly using dotnet-coverage tool

### DIFF
--- a/.github/workflows/dotnet-build-prerelease.yml
+++ b/.github/workflows/dotnet-build-prerelease.yml
@@ -78,16 +78,6 @@ jobs:
         env:
           DOTNET_INSTALL_DIR: ${{ env.DOTNET_INSTALL_DIR }}
 
-      - name: Cache NuGet packages
-        if: runner.os == 'Windows'
-        uses: actions/cache@v3
-        id: cache-nuget
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }} #hash of project files
-          restore-keys: |
-            ${{ runner.os }}-nuget-
-
       - name: Restore NuGet packages
         run: dotnet restore ${{ inputs.SOLUTION_FILE_PATH }}
 

--- a/.github/workflows/dotnet-build-prerelease.yml
+++ b/.github/workflows/dotnet-build-prerelease.yml
@@ -78,6 +78,16 @@ jobs:
         env:
           DOTNET_INSTALL_DIR: ${{ env.DOTNET_INSTALL_DIR }}
 
+      - name: Cache NuGet packages
+        if: runner.os == 'Windows'
+        uses: actions/cache@v3
+        id: cache-nuget
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }} #hash of project files
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
       - name: Restore NuGet packages
         run: dotnet restore ${{ inputs.SOLUTION_FILE_PATH }}
 

--- a/.github/workflows/dotnet-solution-ci-test.yml
+++ b/.github/workflows/dotnet-solution-ci-test.yml
@@ -89,6 +89,7 @@ jobs:
     runs-on: ${{ inputs.OPERATING_SYSTEM }}
 
     env:
+      GITHUB_WORKSPACE: ${{ github.workspace }}
       ARTIFACTS_PATH: ${{ github.workspace }}\artifacts
       TEST_RESULTS_PATH: ${{ github.workspace }}\TestResults
       # Tool versions
@@ -221,7 +222,7 @@ jobs:
       - name: Unzip dotnet-tests-outputs.zip
         shell: pwsh
         run: |
-          Expand-Archive '${{ env.ARTIFACTS_PATH }}\dotnet-tests-outputs.zip' '${{ env.ARTIFACTS_PATH }}'
+          Expand-Archive '${{ env.ARTIFACTS_PATH }}\dotnet-tests-outputs.zip' '${{ env.GITHUB_WORKSPACE }}'
 
       # To ensure code coverage tooling is available in bin folders, teams must use 'publish' on test assemblies
       # See https://github.com/coverlet-coverage/coverlet/issues/521#issuecomment-522429394
@@ -232,13 +233,13 @@ jobs:
           # Configure content root for WebApplicationFactory<TEntryPoint>
           if ( '${{ inputs.ASPNETCORE_TEST_CONTENTROOT_VARIABLE_NAME }}' -ne 'empty' )
           {
-            $Env:${{ inputs.ASPNETCORE_TEST_CONTENTROOT_VARIABLE_NAME }} = '${{ env.ARTIFACTS_PATH }}${{ inputs.ASPNETCORE_TEST_CONTENTROOT_VARIABLE_VALUE }}'
+            $Env:${{ inputs.ASPNETCORE_TEST_CONTENTROOT_VARIABLE_NAME }} = '${{ env.GITHUB_WORKSPACE }}${{ inputs.ASPNETCORE_TEST_CONTENTROOT_VARIABLE_VALUE }}'
           }
           # Handle filter expression
           if ( '${{ inputs.TESTS_FILTER_EXPRESSION }}' -eq 'empty' )
           {
             dotnet test `
-              ${{ env.ARTIFACTS_PATH }}${{ inputs.TESTS_DLL_FILE_PATH }} `
+              ${{ env.GITHUB_WORKSPACE }}${{ inputs.TESTS_DLL_FILE_PATH }} `
               --logger:"console;verbosity=normal" `
               --collect:"XPlat Code Coverage" `
               -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
@@ -246,7 +247,7 @@ jobs:
           else
           {
             dotnet test `
-              ${{ env.ARTIFACTS_PATH }}${{ inputs.TESTS_DLL_FILE_PATH }} `
+              ${{ env.GITHUB_WORKSPACE }}${{ inputs.TESTS_DLL_FILE_PATH }} `
               --filter '${{ inputs.TESTS_FILTER_EXPRESSION }}' `
               --logger:"console;verbosity=normal" `
               --collect:"XPlat Code Coverage" `

--- a/.github/workflows/dotnet-solution-ci-test.yml
+++ b/.github/workflows/dotnet-solution-ci-test.yml
@@ -236,7 +236,6 @@ jobs:
       - name: Run tests and publish report
         shell: pwsh
         run: |
-          dotnet tool install --tool-path ./temp/reportgenerator dotnet-reportgenerator-globaltool
           # Configure content root for WebApplicationFactory<TEntryPoint>
           if ( '${{ inputs.ASPNETCORE_TEST_CONTENTROOT_VARIABLE_NAME }}' -ne 'empty' )
           {

--- a/.github/workflows/dotnet-solution-ci-test.yml
+++ b/.github/workflows/dotnet-solution-ci-test.yml
@@ -236,6 +236,7 @@ jobs:
       - name: Run tests and publish report
         shell: pwsh
         run: |
+          dotnet tool install --global dotnet-coverage
           # Configure content root for WebApplicationFactory<TEntryPoint>
           if ( '${{ inputs.ASPNETCORE_TEST_CONTENTROOT_VARIABLE_NAME }}' -ne 'empty' )
           {
@@ -244,20 +245,16 @@ jobs:
           # Handle filter expression
           if ( '${{ inputs.TESTS_FILTER_EXPRESSION }}' -eq 'empty' )
           {
-            dotnet test `
+            dotnet-coverage collect -f xml -o TestResults\coverage.xml dotnet test `
               ${{ env.GITHUB_WORKSPACE }}${{ inputs.TESTS_DLL_FILE_PATH }} `
               --logger:"console;verbosity=normal" `
-              --collect:"XPlat Code Coverage" `
-              -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
           }
           else
           {
-            dotnet test `
+            dotnet-coverage collect -f xml -o TestResults\coverage.xml dotnet test `
               ${{ env.GITHUB_WORKSPACE }}${{ inputs.TESTS_DLL_FILE_PATH }} `
               --filter '${{ inputs.TESTS_FILTER_EXPRESSION }}' `
               --logger:"console;verbosity=normal" `
-              --collect:"XPlat Code Coverage" `
-              -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
           }
 
       - name: Upload coverage to CodeCov


### PR DESCRIPTION
Usage of the dotnet-coverage code coverage utility - https://learn.microsoft.com/en-us/dotnet/core/additional-tools/dotnet-coverage - for creating coverage report of dotnet code in dotnet-solution-ci-test.yml