### PR TITLE
dep: Update Azurite to 3.19

### DIFF
--- a/.github/workflows/dotnet-solution-ci-test.yml
+++ b/.github/workflows/dotnet-solution-ci-test.yml
@@ -100,7 +100,7 @@ jobs:
       TEST_RESULTS_PATH: ${{ github.workspace }}\TestResults
       # Tool versions
       NODE_VERSION: '16'
-      AZURITE_VERSION: '3.18.0'
+      AZURITE_VERSION: '3.19.0'
       AZURE_FUNCTIONS_CORE_TOOLS_VERSION: '4.0.4670'
       # Necessary to manage Azure resources for tests
       AZURE_KEYVAULT_URL: ${{ secrets.AZURE_KEYVAULT_URL }}

--- a/.github/workflows/dotnet-solution-ci.yml
+++ b/.github/workflows/dotnet-solution-ci.yml
@@ -84,7 +84,7 @@ jobs:
       OUTPUT_PATH: ${{ github.workspace }}\output
       # Tool versions
       NODE_VERSION: '16'
-      AZURITE_VERSION: '3.18.0'
+      AZURITE_VERSION: '3.19.0'
       AZURE_FUNCTIONS_CORE_TOOLS_VERSION: '4.0.4670'
       # Necessary to manage Azure resources for tests
       AZURE_KEYVAULT_URL: ${{ secrets.AZURE_KEYVAULT_URL }}


### PR DESCRIPTION
Newest package https://github.com/Azure/azure-sdk-for-net/releases/tag/Azure.Storage.Blobs_12.14.0 requires https://github.com/Azure/Azurite/releases/tag/v3.19.0, as service API has been updated.