### PR TITLE
dep: Update Azurite to 3.19 in dotnet-setup-and-tools

### DIFF
--- a/.github/actions/dotnet-setup-and-tools/action.yml
+++ b/.github/actions/dotnet-setup-and-tools/action.yml
@@ -36,7 +36,7 @@ inputs:
     default: '16'
   AZURITE_VERSION:
     required: false
-    default: '3.18.0'
+    default: '3.19.0'
   AZURE_FUNCTIONS_CORE_TOOLS_VERSION:
     required: false
     default: '4.0.4670'


### PR DESCRIPTION
Action dotnet-setup-and-tools has an Azurite fallback that needs to be updated too.