### PR TITLE
Remove custom check in dotnet-postbuild-test introduced due to bug in `dotnet-coverage` tool

### DIFF
--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -275,10 +275,6 @@ jobs:
 
           $testFailures = Select-String -Path '.\TestResults\logs.trx' -Pattern '\[FAIL\]'
           $testFailures
-          if ($testFailures.Count -gt 0)
-          {
-            Exit 1
-          }
 
       - name: Upload coverage to CodeCov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -252,7 +252,7 @@ jobs:
       - name: Run tests and publish report
         shell: pwsh
         run: |
-          dotnet tool install --global dotnet-coverage
+          dotnet tool install --global dotnet-coverage --version 17.5.0
           # Configure content root for WebApplicationFactory<TEntryPoint>
           if ( '${{ inputs.ASPNETCORE_TEST_CONTENTROOT_VARIABLE_NAME }}' -ne 'empty' )
           {


### PR DESCRIPTION
Bug was fixed by Microsoft in version 17.5 of the tool.

Verified to work as intended in closed test PR https://github.com/Energinet-DataHub/geh-charges/pull/1867 and the resulting CI executions.