### PR TITLE
Use env instead of secrets in conditions

### DIFF
--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -228,7 +228,7 @@ jobs:
             }
 
       - name: Login to use Azure resources from automated tests
-        if: ${{ env.AZURE_KEYVAULT_URL != '' || env.AZURE_SECRETS_KEYVAULT_URL != '' }}
+        if: ${{ env.AZURE_KEYVAULT_URL != '' || env.AZURE_B2CSECRETS_KEYVAULT_URL != '' }}
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_SPN_ID }}

--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -228,7 +228,7 @@ jobs:
             }
 
       - name: Login to use Azure resources from automated tests
-        if: secrets.AZURE_TENANT_ID != ''
+        if: ${{ env.AZURE_KEYVAULT_URL != '' || env.AZURE_SECRETS_KEYVAULT_URL != '' }}
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_SPN_ID }}

--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -228,7 +228,7 @@ jobs:
             }
 
       - name: Login to use Azure resources from automated tests
-        if: ${{ secrets.AZURE_TENANT_ID != '' }}
+        if: secrets.AZURE_TENANT_ID != ''
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_SPN_ID }}

--- a/.github/workflows/dotnet-solution-ci.yml
+++ b/.github/workflows/dotnet-solution-ci.yml
@@ -218,7 +218,7 @@ jobs:
         run: dotnet build ${{ inputs.SOLUTION_FILE_PATH }} --no-restore --configuration ${{ env.BUILD_CONFIGURATION }}
 
       - name: Login to use Azure resources from automated tests
-        if: ${{ secrets.AZURE_TENANT_ID != '' }}
+        if: ${{ env.AZURE_KEYVAULT_URL != '' || env.AZURE_B2CSECRETS_KEYVAULT_URL != '' }}
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_SPN_ID }}


### PR DESCRIPTION
Load of workflow file failed when using them from the frontend repo, so I had to go back to the previous (working) solution where we look at the URL's instead of the tenant id.

https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/the-outlaws/720