### PR TITLE
Support multiple emails when notifying teams

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+##############################################################
+# Core EditorConfig Options                                  #
+##############################################################
+
+# All files
+[*]
+indent_style = space
+charset = utf-8
+trim_trailing_whitespace = true
+# Unix-style newlines with a newline ending every file
+end_of_line = lf
+insert_final_newline = true
+
+# PowerShell files
+[*.{ps1, psm1, psd1}]
+indent_size = 4
+
+# JSON files
+[*.json]
+indent_size = 4
+
+# YAML files
+[*.{yml,yaml}]
+indent_size = 2

--- a/.github/actions/send-email/Send-EMail.Tests.ps1
+++ b/.github/actions/send-email/Send-EMail.Tests.ps1
@@ -15,12 +15,16 @@
 Describe "When dot-sourcing the script" {
     BeforeAll {
         . $PSScriptRoot/Send-EMail.ps1
+
+        Mock Invoke-WebRequest {}
     }
 
-    Context "Given Send-EMail is called with all parameters" {
-        It "Should not fail" {
+    Context "Given Send-EMail is called with a single to-email-address" {
+        It "Should build a SendGrid request body with one to-email-address" {
             # Act
             Send-EMail `
+                -GitHubRepository "anonymous" `
+                -GitHubRunId "anonymous" `
                 -SendGridApiKey "anonymous" `
                 -TeamName "anonymous" `
                 -To "to@test.com" `

--- a/.github/actions/send-email/Send-EMail.Tests.ps1
+++ b/.github/actions/send-email/Send-EMail.Tests.ps1
@@ -14,13 +14,13 @@
 
 Describe "When running script" {
     BeforeAll {
-        Set-Alias -Name Sut -Value $PSCommandPath.Replace('.Tests.ps1', '.ps1')
+        . $PSScriptRoot/Send-EMail.ps1
     }
 
     Context "Given script is called with all parameters" {
         It "Should not fail" {
             # Act
-            Sut `
+            Send-EMail `
                 -SendGridApiKey "anonymous" `
                 -TeamName "anonymous" `
                 -To "to@test.com" `

--- a/.github/actions/send-email/Send-EMail.Tests.ps1
+++ b/.github/actions/send-email/Send-EMail.Tests.ps1
@@ -1,12 +1,32 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 Describe "When running script" {
     BeforeAll {
         Set-Alias -Name Sut -Value $PSCommandPath.Replace('.Tests.ps1', '.ps1')
     }
 
-    Context "Given script is reachable" {
-        It "Should write EMail parameter" {
+    Context "Given script is called with all parameters" {
+        It "Should not fail" {
             # Act
-            Sut -EMail "test@test.com"
+            Sut `
+                -SendGridApiKey "anonymous" `
+                -TeamName "anonymous" `
+                -To "to@test.com" `
+                -From "from@test.com" `
+                -Subject "anonymous" `
+                -Content "anonymous"
         }
     }
 }

--- a/.github/actions/send-email/Send-EMail.Tests.ps1
+++ b/.github/actions/send-email/Send-EMail.Tests.ps1
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-Describe "When running script" {
+Describe "When dot-sourcing the script" {
     BeforeAll {
         . $PSScriptRoot/Send-EMail.ps1
     }
 
-    Context "Given script is called with all parameters" {
+    Context "Given Send-EMail is called with all parameters" {
         It "Should not fail" {
             # Act
             Send-EMail `

--- a/.github/actions/send-email/Send-EMail.Tests.ps1
+++ b/.github/actions/send-email/Send-EMail.Tests.ps1
@@ -32,10 +32,10 @@ Describe "When dot-sourcing the script" {
                 }
             ]
 "@
-            # Minify JSON
+            # Minify JSON (must use '-AsArray' when we have only one item)
             $expected = $expected
             | ConvertFrom-Json
-            | ConvertTo-Json -Depth 10 -Compress
+            | ConvertTo-Json -Depth 5 -Compress -AsArray
 
             # Act
             $actual = Build-ToEMail -TeamName $teamName -To $to
@@ -68,7 +68,7 @@ Describe "When dot-sourcing the script" {
             # Minify JSON
             $expected = $expected
             | ConvertFrom-Json
-            | ConvertTo-Json -Depth 10 -Compress
+            | ConvertTo-Json -Depth 5 -Compress
 
             # Act
             $actual = Build-ToEMail -TeamName $teamName -To $to

--- a/.github/actions/send-email/Send-EMail.Tests.ps1
+++ b/.github/actions/send-email/Send-EMail.Tests.ps1
@@ -19,18 +19,61 @@ Describe "When dot-sourcing the script" {
         Mock Invoke-WebRequest {}
     }
 
-    Context "Given Send-EMail is called with a single to-email-address" {
-        It "Should build a SendGrid request body with one to-email-address" {
+    Context "Given Build-ToEMail is called with a single to-email-address" {
+        It "Should build a minified JSON array with one email address" {
+            $teamName = "TheOutlaws"
+            $to = "to@test.com"
+
+            $expected = @"
+            [
+                {
+                    "email": "$to",
+                    "name": "$teamName"
+                }
+            ]
+"@
+            # Minify JSON
+            $expected = $expected
+            | ConvertFrom-Json
+            | ConvertTo-Json -Depth 10 -Compress
+
             # Act
-            Send-EMail `
-                -GitHubRepository "anonymous" `
-                -GitHubRunId "anonymous" `
-                -SendGridApiKey "anonymous" `
-                -TeamName "anonymous" `
-                -To "to@test.com" `
-                -From "from@test.com" `
-                -Subject "anonymous" `
-                -Content "anonymous"
+            $actual = Build-ToEMail -TeamName $teamName -To $to
+
+            $actual | Should -Be $expected
+        }
+    }
+
+    Context "Given Build-ToEMail is called with a list of comma-separated to-email-addresses" {
+        It "Should build a minified JSON array with multiple email-addresses sharing the team-name value" {
+            $teamName = "TheOutlaws"
+            $to = "one@test.com, two@test.com, three@test.com"
+
+            $expected = @"
+            [
+                {
+                    "email": "one@test.com",
+                    "name": "$teamName"
+                },
+                {
+                    "email": "two@test.com",
+                    "name": "$teamName"
+                },
+                {
+                    "email": "three@test.com",
+                    "name": "$teamName"
+                }
+            ]
+"@
+            # Minify JSON
+            $expected = $expected
+            | ConvertFrom-Json
+            | ConvertTo-Json -Depth 10 -Compress
+
+            # Act
+            $actual = Build-ToEMail -TeamName $teamName -To $to
+
+            $actual | Should -Be $expected
         }
     }
 }

--- a/.github/actions/send-email/Send-EMail.Tests.ps1
+++ b/.github/actions/send-email/Send-EMail.Tests.ps1
@@ -19,7 +19,7 @@ Describe "When dot-sourcing the script" {
         Mock Invoke-WebRequest {}
     }
 
-    Context "Given Build-ToEMail is called with a single to-email-address" {
+    Context "Given Build-ToEMail is called with a single 'to' email address" {
         It "Should build a minified JSON array with one email address" {
             $teamName = "TheOutlaws"
             $to = "to@test.com"
@@ -44,8 +44,8 @@ Describe "When dot-sourcing the script" {
         }
     }
 
-    Context "Given Build-ToEMail is called with a list of comma-separated to-email-addresses" {
-        It "Should build a minified JSON array with multiple email-addresses sharing the team-name value" {
+    Context "Given Build-ToEMail is called with a list of comma-separated 'to' email addresses" {
+        It "Should build a minified JSON array with multiple email addresses sharing the team name value" {
             $teamName = "TheOutlaws"
             $to = "one@test.com, two@test.com, three@test.com"
 

--- a/.github/actions/send-email/Send-EMail.Tests.ps1
+++ b/.github/actions/send-email/Send-EMail.Tests.ps1
@@ -1,0 +1,12 @@
+Describe "When running script" {
+    BeforeAll {
+        Set-Alias -Name Sut -Value $PSCommandPath.Replace('.Tests.ps1', '.ps1')
+    }
+
+    Context "Given script is reachable" {
+        It "Should write EMail parameter" {
+            # Act
+            Sut -EMail "test@test.com"
+        }
+    }
+}

--- a/.github/actions/send-email/Send-EMail.ps1
+++ b/.github/actions/send-email/Send-EMail.ps1
@@ -99,7 +99,7 @@ function Send-EMail {
 
 <#
     .SYNOPSIS
-    Build the 'to' part of the body for the SendGrid send mail request.
+    Build the 'to' part of the JSON body for the SendGrid 'send mail' request.
 #>
 function Build-ToEMail {
     param (
@@ -113,6 +113,18 @@ function Build-ToEMail {
         $To
     )
 
-    $emails = $To.Split(',')
+    $emails = $To.Split(',').Trim()
+    $eMailAndNameArray = $emails | ForEach-Object { [PSCustomObject]@{
+            email = $PSItem
+            name  = $TeamName
+        } }
 
+    $eMailAndNameArrayAsJson = ConvertTo-Json $eMailAndNameArray -AsArray
+
+    # Minified JSON is easier to compare in tests
+    $eMailAndNameArrayAsJson = ($eMailAndNameArrayAsJson
+        | ConvertFrom-Json
+        | ConvertTo-Json -Depth 10 -Compress)
+
+    return ($eMailAndNameArrayAsJson)
 }

--- a/.github/actions/send-email/Send-EMail.ps1
+++ b/.github/actions/send-email/Send-EMail.ps1
@@ -56,7 +56,7 @@ function Send-EMail {
         $Content = ""
     )
 
-    Write-Host "Sending email from '$GitHubRepository' for build with id '$GitHubRunId'"
+    Write-Host "Sending email from '$GitHubRepository' for build with run id '$GitHubRunId'"
 
     $finalTo = ""
     $finalContent = "<a href=https://github.com/$GitHubRepository/actions/runs/$GitHubRunId target=_blank>Link to Github job run</a> $Content"

--- a/.github/actions/send-email/Send-EMail.ps1
+++ b/.github/actions/send-email/Send-EMail.ps1
@@ -80,7 +80,6 @@ function Send-EMail {
         ]
     }
 "@
-    Write-Host "Body: $body"
 
     try {
         $response = Invoke-WebRequest -Uri 'https://api.sendgrid.com/v3/mail/send' -Method Post `
@@ -119,12 +118,14 @@ function Build-ToEMail {
             name  = $TeamName
         } }
 
-    $eMailAndNameArrayAsJson = ConvertTo-Json $eMailAndNameArray -AsArray
-
-    # Minified JSON is easier to compare in tests
-    $eMailAndNameArrayAsJson = ($eMailAndNameArrayAsJson
-        | ConvertFrom-Json
-        | ConvertTo-Json -Depth 10 -Compress)
-
-    return ($eMailAndNameArrayAsJson)
+    if ($emails.Count -eq 1) {
+        # -AsArray ensures that arrays with 1 element are converted correctly
+        # See https://stackoverflow.com/questions/18662967/convertto-json-an-array-with-a-single-item for details
+        [string]$eMailAndNameArrayAsJson = ConvertTo-Json $eMailAndNameArray -Depth 5 -Compress -AsArray
+        return ($eMailAndNameArrayAsJson)
+    }
+    else {
+        [string]$eMailAndNameArrayAsJson = ConvertTo-Json $eMailAndNameArray -Depth 5 -Compress
+        return ($eMailAndNameArrayAsJson)
+    }
 }

--- a/.github/actions/send-email/Send-EMail.ps1
+++ b/.github/actions/send-email/Send-EMail.ps1
@@ -58,7 +58,7 @@ function Send-EMail {
 
     Write-Host "Sending email from '$GitHubRepository' for build with run id '$GitHubRunId'"
 
-    $finalTo = ""
+    $finalTo = Build-ToEMail -TeamName $TeamName -To $To
     $finalContent = "<a href=https://github.com/$GitHubRepository/actions/runs/$GitHubRunId target=_blank>Link to Github job run</a> $Content"
 
     $body = @"
@@ -95,4 +95,24 @@ function Send-EMail {
     }
 
     Write-Host "Sent email"
+}
+
+<#
+    .SYNOPSIS
+    Build the 'to' part of the body for the SendGrid send mail request.
+#>
+function Build-ToEMail {
+    param (
+        # The name of the team who should receive the email. When sending to multiple recipients this name will be used for all of them.
+        [Parameter(Mandatory = $true)]
+        [string]
+        $TeamName,
+        # The email to-address. Should contain either a single email or a list of comma separated emails.
+        [Parameter(Mandatory = $true)]
+        [string]
+        $To
+    )
+
+    $emails = $To.Split(',')
+
 }

--- a/.github/actions/send-email/Send-EMail.ps1
+++ b/.github/actions/send-email/Send-EMail.ps1
@@ -45,7 +45,7 @@ param (
     # Additional content for the email body. Apart from this the email body will also always contain a link to the failed build.
     [Parameter(Mandatory = $false)]
     [string]
-    $Content
+    $Content = ""
 )
 
 Write-Host "To: '$To'"

--- a/.github/actions/send-email/Send-EMail.ps1
+++ b/.github/actions/send-email/Send-EMail.ps1
@@ -1,3 +1,17 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 <#
     .SYNOPSIS
     Send emails using SendGrid.
@@ -8,10 +22,30 @@
 #>
 
 param (
-    # Should contain either a single email or a list of comma separated emails.
+    # A valid SendGrid API key.
     [Parameter(Mandatory = $true)]
     [string]
-    $EMail
+    $SendGridApiKey,
+    # The name of the team who should receive the email. When sending to multiple recipients this name will be used for all of them.
+    [Parameter(Mandatory = $true)]
+    [string]
+    $TeamName,
+    # The email to-address. Should contain either a single email or a list of comma separated emails.
+    [Parameter(Mandatory = $true)]
+    [string]
+    $To,
+    # The email from-address.
+    [Parameter(Mandatory = $true)]
+    [string]
+    $From,
+    # The email subject. Should contain environment information when possible.
+    [Parameter(Mandatory = $true)]
+    [string]
+    $Subject,
+    # Additional content for the email body. Apart from this the email body will also always contain a link to the failed build.
+    [Parameter(Mandatory = $false)]
+    [string]
+    $Content
 )
 
-Write-Host "Email: '$EMail'"
+Write-Host "To: '$To'"

--- a/.github/actions/send-email/Send-EMail.ps1
+++ b/.github/actions/send-email/Send-EMail.ps1
@@ -82,11 +82,9 @@ function Send-EMail {
 "@
 
     try {
-        $response = Invoke-WebRequest -Uri 'https://api.sendgrid.com/v3/mail/send' -Method Post `
+        Invoke-WebRequest -Uri 'https://api.sendgrid.com/v3/mail/send' -Method Post `
             -Headers @{Authorization = "Bearer $SendgridApiKey" } `
             -ContentType 'application/json' -Body $body
-
-        Write-Host "Response: $response"
     }
     catch {
         $errorMessage = $_.Exception.Message

--- a/.github/actions/send-email/Send-EMail.ps1
+++ b/.github/actions/send-email/Send-EMail.ps1
@@ -49,3 +49,12 @@ param (
 )
 
 Write-Host "To: '$To'"
+
+# #     curl -s -o /dev/null -w "HttpStatus: %{http_code}" -X POST  https://api.sendgrid.com/v3/mail/send \
+# #       --header "Authorization: Bearer ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}" \
+# #       --header "Content-Type: application/json" \
+# #       --data '{"personalizations":[
+# #         {"to":[{"email":"${{ steps.get_email.outputs.TEAM_EMAIL }}","name":"${{ inputs.TEAM_NAME }}"}]}],
+# #         "from":{"email":"${{ secrets.EMAIL_SENDER }}","name":"DataHub Github"},
+# #         "subject":"${{ inputs.SUBJECT }}",
+# #         "content":[{"type":"text/html","value":"<a href=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} target=_blank>Link to Github job run</a>  ${{ inputs.BODY }}"}]}'

--- a/.github/actions/send-email/Send-EMail.ps1
+++ b/.github/actions/send-email/Send-EMail.ps1
@@ -20,41 +20,42 @@
     The script sends emails using SendGrid. The input can either be a single email
     or a list of comma separated emails.
 #>
+function Send-EMail {
+    param (
+        # A valid SendGrid API key.
+        [Parameter(Mandatory = $true)]
+        [string]
+        $SendGridApiKey,
+        # The name of the team who should receive the email. When sending to multiple recipients this name will be used for all of them.
+        [Parameter(Mandatory = $true)]
+        [string]
+        $TeamName,
+        # The email to-address. Should contain either a single email or a list of comma separated emails.
+        [Parameter(Mandatory = $true)]
+        [string]
+        $To,
+        # The email from-address.
+        [Parameter(Mandatory = $true)]
+        [string]
+        $From,
+        # The email subject. Should contain environment information when possible.
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Subject,
+        # Additional content for the email body. Apart from this the email body will also always contain a link to the failed build.
+        [Parameter(Mandatory = $false)]
+        [string]
+        $Content = ""
+    )
 
-param (
-    # A valid SendGrid API key.
-    [Parameter(Mandatory = $true)]
-    [string]
-    $SendGridApiKey,
-    # The name of the team who should receive the email. When sending to multiple recipients this name will be used for all of them.
-    [Parameter(Mandatory = $true)]
-    [string]
-    $TeamName,
-    # The email to-address. Should contain either a single email or a list of comma separated emails.
-    [Parameter(Mandatory = $true)]
-    [string]
-    $To,
-    # The email from-address.
-    [Parameter(Mandatory = $true)]
-    [string]
-    $From,
-    # The email subject. Should contain environment information when possible.
-    [Parameter(Mandatory = $true)]
-    [string]
-    $Subject,
-    # Additional content for the email body. Apart from this the email body will also always contain a link to the failed build.
-    [Parameter(Mandatory = $false)]
-    [string]
-    $Content = ""
-)
+    Write-Host "To: '$To'"
 
-Write-Host "To: '$To'"
-
-# #     curl -s -o /dev/null -w "HttpStatus: %{http_code}" -X POST  https://api.sendgrid.com/v3/mail/send \
-# #       --header "Authorization: Bearer ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}" \
-# #       --header "Content-Type: application/json" \
-# #       --data '{"personalizations":[
-# #         {"to":[{"email":"${{ steps.get_email.outputs.TEAM_EMAIL }}","name":"${{ inputs.TEAM_NAME }}"}]}],
-# #         "from":{"email":"${{ secrets.EMAIL_SENDER }}","name":"DataHub Github"},
-# #         "subject":"${{ inputs.SUBJECT }}",
-# #         "content":[{"type":"text/html","value":"<a href=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} target=_blank>Link to Github job run</a>  ${{ inputs.BODY }}"}]}'
+    # #     curl -s -o /dev/null -w "HttpStatus: %{http_code}" -X POST  https://api.sendgrid.com/v3/mail/send \
+    # #       --header "Authorization: Bearer ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}" \
+    # #       --header "Content-Type: application/json" \
+    # #       --data '{"personalizations":[
+    # #         {"to":[{"email":"${{ steps.get_email.outputs.TEAM_EMAIL }}","name":"${{ inputs.TEAM_NAME }}"}]}],
+    # #         "from":{"email":"${{ secrets.EMAIL_SENDER }}","name":"DataHub Github"},
+    # #         "subject":"${{ inputs.SUBJECT }}",
+    # #         "content":[{"type":"text/html","value":"<a href=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} target=_blank>Link to Github job run</a>  ${{ inputs.BODY }}"}]}'
+}

--- a/.github/actions/send-email/Send-EMail.ps1
+++ b/.github/actions/send-email/Send-EMail.ps1
@@ -37,7 +37,7 @@ function Send-EMail {
         [Parameter(Mandatory = $true)]
         [string]
         $TeamName,
-        # The email to-address. Should contain either a single email or a list of comma separated emails.
+        # The email to-address. Must contain either a single email or a list of comma separated emails.
         [Parameter(Mandatory = $true)]
         [string]
         $To,
@@ -106,7 +106,7 @@ function Build-ToEMail {
         [Parameter(Mandatory = $true)]
         [string]
         $TeamName,
-        # The email to-address. Should contain either a single email or a list of comma separated emails.
+        # The email to-address. Must contain either a single email or a list of comma separated emails.
         [Parameter(Mandatory = $true)]
         [string]
         $To

--- a/.github/actions/send-email/Send-EMail.ps1
+++ b/.github/actions/send-email/Send-EMail.ps1
@@ -1,0 +1,17 @@
+<#
+    .SYNOPSIS
+    Send emails using SendGrid.
+
+    .DESCRIPTION
+    The script sends emails using SendGrid. The input can either be a single email
+    or a list of comma separated emails.
+#>
+
+param (
+    # Should contain either a single email or a list of comma separated emails.
+    [Parameter(Mandatory = $true)]
+    [string]
+    $EMail
+)
+
+Write-Host "Email: '$EMail'"

--- a/.github/actions/send-email/Send-EMail.ps1
+++ b/.github/actions/send-email/Send-EMail.ps1
@@ -17,8 +17,7 @@
     Send emails using SendGrid.
 
     .DESCRIPTION
-    The script sends emails using SendGrid. The input can either be a single email
-    or a list of comma separated emails.
+    The script sends emails using SendGrid. It supports sending to one or multiple recipients.
 #>
 function Send-EMail {
     param (

--- a/.github/actions/send-email/Send-EMail.ps1
+++ b/.github/actions/send-email/Send-EMail.ps1
@@ -80,6 +80,7 @@ function Send-EMail {
         ]
     }
 "@
+    Write-Host "Body: $body"
 
     try {
         $response = Invoke-WebRequest -Uri 'https://api.sendgrid.com/v3/mail/send' -Method Post `

--- a/.github/actions/send-email/action.yaml
+++ b/.github/actions/send-email/action.yaml
@@ -43,6 +43,8 @@ runs:
       run: |
         . ${{ github.action_path }}/Send-EMail.ps1
         Send-EMail `
+          -GitHubRepository "${{ github.repository }}"
+          -GitHubRunId "${{ github.run_id }}"
           -SendGridApiKey "${{ inputs.sendgrid-api-key }}" `
           -TeamName "${{ inputs.team-name }}" `
           -To "${{ inputs.to }}" `

--- a/.github/actions/send-email/action.yaml
+++ b/.github/actions/send-email/action.yaml
@@ -41,7 +41,8 @@ runs:
     - name: Run PowerShell script
       shell: pwsh
       run: |
-        ${{ github.action_path }}/Send-EMail.ps1 `
+        . ${{ github.action_path }}/Send-EMail.ps1
+        Send-EMail `
           -SendGridApiKey "${{ inputs.sendgrid-api-key }}" `
           -TeamName "${{ inputs.team-name }}" `
           -To "${{ inputs.to }}" `

--- a/.github/actions/send-email/action.yaml
+++ b/.github/actions/send-email/action.yaml
@@ -22,7 +22,7 @@ inputs:
     description: The name of the team who should receive the email. When sending to multiple recipients this name will be used for all of them.
     required: true
   to:
-    description: The email to-address. Should contain either a single email or a list of comma separated emails.
+    description: The email to-address. Must contain either a single email or a list of comma separated emails.
     required: true
   from:
     description: The email from-address.

--- a/.github/actions/send-email/action.yaml
+++ b/.github/actions/send-email/action.yaml
@@ -40,5 +40,10 @@ runs:
     - name: Run PowerShell script
       shell: pwsh
       run: |
-        ${{ github.action_path }}/Send-EMail.ps1
-
+        ${{ github.action_path }}/Send-EMail.ps1 `
+          -To ${{ inputs.to }} `
+          -To ${{ inputs.to }} `
+          -To ${{ inputs.to }} `
+          -To ${{ inputs.to }} `
+          -To ${{ inputs.to }} `
+          -To ${{ inputs.to }}

--- a/.github/actions/send-email/action.yaml
+++ b/.github/actions/send-email/action.yaml
@@ -1,0 +1,29 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Send email
+description: Send email to one or multiple recipients
+inputs:
+  email:
+    description: Should contain either a single email or a list of comma separated emails.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Run PowerShell script
+      shell: pwsh
+      run: |
+        ${{ github.action_path }}/Send-EMail.ps1 -EMail ${{ inputs.email }}
+

--- a/.github/actions/send-email/action.yaml
+++ b/.github/actions/send-email/action.yaml
@@ -32,7 +32,7 @@ inputs:
     required: true
   content:
     description: Additional content for the email body. Apart from this the email body will also always contain a link to the failed build.
-    required: true
+    required: false
 
 runs:
   using: composite

--- a/.github/actions/send-email/action.yaml
+++ b/.github/actions/send-email/action.yaml
@@ -42,9 +42,9 @@ runs:
       shell: pwsh
       run: |
         ${{ github.action_path }}/Send-EMail.ps1 `
-          -SendGridApiKey ${{ inputs.sendgrid-api-key }} `
-          -TeamName ${{ inputs.team-name }} `
-          -To ${{ inputs.to }} `
-          -From ${{ inputs.from }} `
-          -Subject ${{ inputs.subject }} `
-          -Content ${{ inputs.content }}
+          -SendGridApiKey "${{ inputs.sendgrid-api-key }}" `
+          -TeamName "${{ inputs.team-name }}" `
+          -To "${{ inputs.to }}" `
+          -From "${{ inputs.from }}" `
+          -Subject "${{ inputs.subject }}" `
+          -Content "${{ inputs.content }}"

--- a/.github/actions/send-email/action.yaml
+++ b/.github/actions/send-email/action.yaml
@@ -43,8 +43,8 @@ runs:
       run: |
         . ${{ github.action_path }}/Send-EMail.ps1
         Send-EMail `
-          -GitHubRepository "${{ github.repository }}"
-          -GitHubRunId "${{ github.run_id }}"
+          -GitHubRepository "${{ github.repository }}" `
+          -GitHubRunId "${{ github.run_id }}" `
           -SendGridApiKey "${{ inputs.sendgrid-api-key }}" `
           -TeamName "${{ inputs.team-name }}" `
           -To "${{ inputs.to }}" `

--- a/.github/actions/send-email/action.yaml
+++ b/.github/actions/send-email/action.yaml
@@ -33,6 +33,7 @@ inputs:
   content:
     description: Additional content for the email body. Apart from this the email body will also always contain a link to the failed build.
     required: false
+    default: ''
 
 runs:
   using: composite

--- a/.github/actions/send-email/action.yaml
+++ b/.github/actions/send-email/action.yaml
@@ -41,9 +41,9 @@ runs:
       shell: pwsh
       run: |
         ${{ github.action_path }}/Send-EMail.ps1 `
+          -SendGridApiKey ${{ inputs.sendgrid-api-key }} `
+          -TeamName ${{ inputs.team-name }} `
           -To ${{ inputs.to }} `
-          -To ${{ inputs.to }} `
-          -To ${{ inputs.to }} `
-          -To ${{ inputs.to }} `
-          -To ${{ inputs.to }} `
-          -To ${{ inputs.to }}
+          -From ${{ inputs.from }} `
+          -Subject ${{ inputs.subject }} `
+          -Content ${{ inputs.content }}

--- a/.github/actions/send-email/action.yaml
+++ b/.github/actions/send-email/action.yaml
@@ -15,8 +15,23 @@
 name: Send email
 description: Send email to one or multiple recipients
 inputs:
-  email:
-    description: Should contain either a single email or a list of comma separated emails.
+  sendgrid-api-key:
+    description: A valid SendGrid API key.
+    required: true
+  team-name:
+    description: The name of the team who should receive the email. When sending to multiple recipients this name will be used for all of them.
+    required: true
+  to:
+    description: The email to-address. Should contain either a single email or a list of comma separated emails.
+    required: true
+  from:
+    description: The email from-address.
+    required: true
+  subject:
+    description: The email subject. Should contain environment information when possible.
+    required: true
+  content:
+    description: Additional content for the email body. Apart from this the email body will also always contain a link to the failed build.
     required: true
 
 runs:
@@ -25,5 +40,5 @@ runs:
     - name: Run PowerShell script
       shell: pwsh
       run: |
-        ${{ github.action_path }}/Send-EMail.ps1 -EMail ${{ inputs.email }}
+        ${{ github.action_path }}/Send-EMail.ps1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Check YAML consistency
     runs-on: ubuntu-latest
     steps:
-    - name: 'Checkout'
+    - name: Checkout
       uses: actions/checkout@v3
 
     - name: Run yamllint on .github/workflows folder
@@ -34,6 +34,13 @@ jobs:
       uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@v10
       with:
         yaml_file_or_folder: .github/actions
+
+  powershell_workflows:
+    name: Verify PowerShell scripts
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
 
     - name: Run Pester tests
       shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
       uses: Energinet-DataHub/.github/.github/actions/create-release-tag@v10
       with:
         MAJOR_VERSION: 10
-        MINOR_VERSION: 3
-        PATCH_VERSION: 5
+        MINOR_VERSION: 4
+        PATCH_VERSION: 0
         REPOSITORY_PATH: 'Energinet-DataHub/.github'
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,34 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-name: CI
+name: .github - CI
+
+# DESCRIPTION:
+#
+# This workflow handles the following:
+#  * Verifies YAML files (workflows/actions) conduct to the defined coding standard.
+#  * Runs Pester tests located within "actions" folders.
+#  * PR: Verifies a release does not exists with the given semantic version.
+#  * Merge to main: Creates a new release with the given semantic version.
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
 
 jobs:
   yamllint_workflows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Run Pester tests
       shell: pwsh
       run: |
-        Invoke-Pester -Output 'Detailed' -CI
+        Invoke-Pester -Output 'Detailed' -CI *.Tests.ps1
 
   createrelease:
     name: Create release tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         yaml_file_or_folder: .github/actions
 
-  powershell_workflows:
+  powershell_verification:
     name: Verify PowerShell scripts
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,12 @@ jobs:
     - name: Validate input fields in .github/actions folder
       uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@v10
       with:
-        yaml_file_or_folder: .github/actions        
+        yaml_file_or_folder: .github/actions
+
+    - name: Run Pester tests
+      shell: pwsh
+      run: |
+        Invoke-Pester -Output 'Detailed' -CI
 
   createrelease:
     name: Create release tag
@@ -47,5 +52,5 @@ jobs:
         MINOR_VERSION: 3
         PATCH_VERSION: 5
         REPOSITORY_PATH: 'Energinet-DataHub/.github'
-      env: 
+      env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
 
     - name: Run Pester tests
       shell: pwsh
+      working-directory: .github/actions
       run: |
         Invoke-Pester -Output 'Detailed' -CI *.Tests.ps1
 

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -68,7 +68,7 @@ jobs:
           echo "TEAM_EMAIL=$TEAM_EMAIL" >>$GITHUB_OUTPUT
 
       - name: Send email
-        uses: Energinet-DataHub/.github/.github/actions/send-email #@xdast # TODO: Update ref to v10 when merged
+        uses: Energinet-DataHub/.github/.github/actions/send-email@xdast # TODO: Update ref to v10 when merged
         with:
           sendgrid-api-key: ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}
           team-name: ${{ inputs.TEAM_NAME }}

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -68,7 +68,7 @@ jobs:
           echo "TEAM_EMAIL=$TEAM_EMAIL" >>$GITHUB_OUTPUT
 
       - name: Send email
-        uses: xxx
+        uses: uses: Energinet-DataHub/.github/.github/actions/yaml-lint@xdast # TODO: Update ref to v10 when merged
         with:
           sendgrid-api-key: ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}
           team-name: ${{ inputs.TEAM_NAME }}

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -68,7 +68,7 @@ jobs:
           echo "TEAM_EMAIL=$TEAM_EMAIL" >>$GITHUB_OUTPUT
 
       - name: Send email
-        uses: uses: Energinet-DataHub/.github/.github/actions/send-email@xdast # TODO: Update ref to v10 when merged
+        uses: Energinet-DataHub/.github/.github/actions/send-email@xdast # TODO: Update ref to v10 when merged
         with:
           sendgrid-api-key: ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}
           team-name: ${{ inputs.TEAM_NAME }}

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -68,7 +68,8 @@ jobs:
           echo "TEAM_EMAIL=$TEAM_EMAIL" >>$GITHUB_OUTPUT
 
       - name: Send email
-        uses: Energinet-DataHub/.github/.github/actions/send-email@xdast # TODO: Update ref to v10 when merged
+        #uses: Energinet-DataHub/.github/.github/actions/send-email@xdast # TODO: Update ref to v10 when merged
+        uses:  ./.github/actions/send-email
         with:
           sendgrid-api-key: ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}
           team-name: ${{ inputs.TEAM_NAME }}

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -16,7 +16,7 @@ name: Notify team
 
 # DESCRIPTION:
 # This workflow is used to notify teams about failing deployments
-# by sending an email to their MS Team Channel.
+# by sending an email to their MS Team Channel or possibly direct mails.
 #
 # The workflow must be called using 'secrets: inherit' to get access
 # to necessary secrets.
@@ -68,12 +68,23 @@ jobs:
           echo "TEAM_EMAIL=$TEAM_EMAIL" >>$GITHUB_OUTPUT
 
       - name: Send email
+        uses: xxx
+        with:
+          sendgrid-api-key: ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}
+          team-name: ${{ inputs.TEAM_NAME }}
+          to: ${{ steps.get_email.outputs.TEAM_EMAIL }}
+          from: ${{ secrets.EMAIL_SENDER }}
+          subject: ${{ inputs.SUBJECT }}
+          content: ${{ inputs.BODY }}
 
-
-      - name: Send email
-        shell: bash
-        run: |
-          curl -s -o /dev/null -w "HttpStatus: %{http_code}" -X POST  https://api.sendgrid.com/v3/mail/send \
-            --header "Authorization: Bearer ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}" \
-            --header "Content-Type: application/json" \
-            --data '{"personalizations":[{"to":[{"email":"${{ steps.get_email.outputs.TEAM_EMAIL }}","name":"${{ inputs.TEAM_NAME }}"}]}],"from":{"email":"${{ secrets.EMAIL_SENDER }}","name":"DataHub Github"},"subject":"${{ inputs.SUBJECT }}","content":[{"type":"text/html","value":"<a href=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} target=_blank>Link to Github job run</a>  ${{ inputs.BODY }}"}]}'
+      # # - name: Send email
+      # #   shell: bash
+      # #   run: |
+      # #     curl -s -o /dev/null -w "HttpStatus: %{http_code}" -X POST  https://api.sendgrid.com/v3/mail/send \
+      # #       --header "Authorization: Bearer ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}" \
+      # #       --header "Content-Type: application/json" \
+      # #       --data '{"personalizations":[
+      # #         {"to":[{"email":"${{ steps.get_email.outputs.TEAM_EMAIL }}","name":"${{ inputs.TEAM_NAME }}"}]}],
+      # #         "from":{"email":"${{ secrets.EMAIL_SENDER }}","name":"DataHub Github"},
+      # #         "subject":"${{ inputs.SUBJECT }}",
+      # #         "content":[{"type":"text/html","value":"<a href=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} target=_blank>Link to Github job run</a>  ${{ inputs.BODY }}"}]}'

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -69,7 +69,6 @@ jobs:
 
       - name: Send email
         uses: Energinet-DataHub/.github/.github/actions/send-email@xdast # TODO: Update ref to v10 when merged
-        uses:  ./.github/actions/send-email
         with:
           sendgrid-api-key: ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}
           team-name: ${{ inputs.TEAM_NAME }}

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -68,6 +68,9 @@ jobs:
           echo "TEAM_EMAIL=$TEAM_EMAIL" >>$GITHUB_OUTPUT
 
       - name: Send email
+
+
+      - name: Send email
         shell: bash
         run: |
           curl -s -o /dev/null -w "HttpStatus: %{http_code}" -X POST  https://api.sendgrid.com/v3/mail/send \

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -68,7 +68,7 @@ jobs:
           echo "TEAM_EMAIL=$TEAM_EMAIL" >>$GITHUB_OUTPUT
 
       - name: Send email
-        uses: uses: Energinet-DataHub/.github/.github/actions/yaml-lint@xdast # TODO: Update ref to v10 when merged
+        uses: uses: Energinet-DataHub/.github/.github/actions/send-email@xdast # TODO: Update ref to v10 when merged
         with:
           sendgrid-api-key: ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}
           team-name: ${{ inputs.TEAM_NAME }}

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -76,15 +76,3 @@ jobs:
           from: ${{ secrets.EMAIL_SENDER }}
           subject: ${{ inputs.SUBJECT }}
           content: ${{ inputs.BODY }}
-
-      # # - name: Send email
-      # #   shell: bash
-      # #   run: |
-      # #     curl -s -o /dev/null -w "HttpStatus: %{http_code}" -X POST  https://api.sendgrid.com/v3/mail/send \
-      # #       --header "Authorization: Bearer ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}" \
-      # #       --header "Content-Type: application/json" \
-      # #       --data '{"personalizations":[
-      # #         {"to":[{"email":"${{ steps.get_email.outputs.TEAM_EMAIL }}","name":"${{ inputs.TEAM_NAME }}"}]}],
-      # #         "from":{"email":"${{ secrets.EMAIL_SENDER }}","name":"DataHub Github"},
-      # #         "subject":"${{ inputs.SUBJECT }}",
-      # #         "content":[{"type":"text/html","value":"<a href=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} target=_blank>Link to Github job run</a>  ${{ inputs.BODY }}"}]}'

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -68,7 +68,7 @@ jobs:
           echo "TEAM_EMAIL=$TEAM_EMAIL" >>$GITHUB_OUTPUT
 
       - name: Send email
-        uses: Energinet-DataHub/.github/.github/actions/send-email@xdast # TODO: Update ref to v10 when merged
+        uses: Energinet-DataHub/.github/.github/actions/send-email #@xdast # TODO: Update ref to v10 when merged
         with:
           sendgrid-api-key: ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}
           team-name: ${{ inputs.TEAM_NAME }}

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -68,7 +68,7 @@ jobs:
           echo "TEAM_EMAIL=$TEAM_EMAIL" >>$GITHUB_OUTPUT
 
       - name: Send email
-        #uses: Energinet-DataHub/.github/.github/actions/send-email@xdast # TODO: Update ref to v10 when merged
+        uses: Energinet-DataHub/.github/.github/actions/send-email@xdast # TODO: Update ref to v10 when merged
         uses:  ./.github/actions/send-email
         with:
           sendgrid-api-key: ${{ secrets.SENDGRID_INSTANCE_SYSTEM_NOTIFICATIONS_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@
 *.userosscache
 *.sln.docstates
 *.idea*
-.vscode/
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
@@ -392,3 +391,11 @@ src/streaming/geh_stream.egg-info/
 .terraform
 .terraform.lock.hcl
 build/terraform/**/*.tfvars
+
+# VS Code files for those working on multiple tools
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ Generated\ Files/
 TestResult.xml
 nunit-*.xml
 
+# Pester
+testResults.xml
+
 # Build Results of an ATL Project
 [Dd]ebugPS/
 [Rr]eleasePS/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+    // List of extensions which should be recommended for users of this workspace.
+    "recommendations": [
+        "editorconfig.editorconfig",
+        "davidanson.vscode-markdownlint",
+        "ms-vscode.powershell"
+    ],
+    // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+    "unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "powershell.codeFormatting.avoidSemicolonsAsLineTerminators": true,
+    "powershell.codeFormatting.useCorrectCasing": true,
+    "powershell.codeFormatting.whitespaceBetweenParameters": true
+}


### PR DESCRIPTION
Update `notify-team.yml` workflow to be able to send notifications to multiple emails.

https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/the-outlaws/942

Can be tested using the following branch in dh3-infrastructure:
https://github.com/Energinet-DataHub/dh3-infrastructure/tree/dstenroejl/test-notify-team