### PR TITLE
Move validation to script

### DIFF
--- a/.github/actions/github-actions-input-name-validate/Assert-GitHubActionsInputNames.ps1
+++ b/.github/actions/github-actions-input-name-validate/Assert-GitHubActionsInputNames.ps1
@@ -16,14 +16,13 @@ Import-Module PowerShell-Yaml -Force
 
 <#
     .SYNOPSIS
-    Determines whether all input parameters in GitHub action and workflow files are valid.
+    Assert all input parameters in GitHub action and workflow files are valid.
 
     .DESCRIPTION
-    Determines whether all input parameters in GitHub action and workflow files are lowercase.
-    It validates the definitions as well as any usage of all input patameters.
-    It returns `$True` if all input parameters are valid; otherwise `$False`.
+    Assert all input parameters in GitHub action and workflow files are lowercase.
+    It asserts the definitions as well as any usage of all input patameters.
 #>
-function Test-GitHubActionsInputNames {
+function Assert-GitHubActionsInputNames {
     param (
         # The folder path in which to search for relevant files to validate.
         [Parameter(Mandatory = $true)]

--- a/.github/actions/github-actions-input-name-validate/Assert-GitHubActionsInputNames.ps1
+++ b/.github/actions/github-actions-input-name-validate/Assert-GitHubActionsInputNames.ps1
@@ -53,5 +53,8 @@ function Test-GitHubActionsInputNames {
         }
     }
 
-    return $isValid
+    if (-not $isValid) {
+        throw 'One or more input parameters contain uppercase characters'
+        exit 1
+    }
 }

--- a/.github/actions/github-actions-input-name-validate/Assert-GitHubActionsInputNames.ps1
+++ b/.github/actions/github-actions-input-name-validate/Assert-GitHubActionsInputNames.ps1
@@ -53,6 +53,6 @@ function Assert-GitHubActionsInputNames {
     }
 
     if (-not $isValid) {
-        Write-Error 'One or more input parameters contain uppercase characters'
+        throw 'One or more input parameters contain uppercase characters'
     }
 }

--- a/.github/actions/github-actions-input-name-validate/Assert-GitHubActionsInputNames.ps1
+++ b/.github/actions/github-actions-input-name-validate/Assert-GitHubActionsInputNames.ps1
@@ -54,6 +54,5 @@ function Assert-GitHubActionsInputNames {
 
     if (-not $isValid) {
         throw 'One or more input parameters contain uppercase characters'
-        exit 1
     }
 }

--- a/.github/actions/github-actions-input-name-validate/Assert-GitHubActionsInputNames.ps1
+++ b/.github/actions/github-actions-input-name-validate/Assert-GitHubActionsInputNames.ps1
@@ -53,6 +53,6 @@ function Assert-GitHubActionsInputNames {
     }
 
     if (-not $isValid) {
-        throw 'One or more input parameters contain uppercase characters'
+        Write-Error 'One or more input parameters contain uppercase characters'
     }
 }

--- a/.github/actions/github-actions-input-name-validate/Test-GitHubActionsInputNames.ps1
+++ b/.github/actions/github-actions-input-name-validate/Test-GitHubActionsInputNames.ps1
@@ -1,0 +1,57 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Import-Module PowerShell-Yaml -Force
+
+<#
+    .SYNOPSIS
+    Determines whether all input parameters in GitHub action and workflow files are valid.
+
+    .DESCRIPTION
+    Determines whether all input parameters in GitHub action and workflow files are lowercase.
+    It validates the definitions as well as any usage of all input patameters.
+    It returns `$True` if all input parameters are valid; otherwise `$False`.
+#>
+function Test-GitHubActionsInputNames {
+    param (
+        # The folder path in which to search for relevant files to validate.
+        [Parameter(Mandatory = $true)]
+        [string]
+        $FolderPath
+    )
+    $isValid = $true
+
+    $files = Get-ChildItem -Path $folder -Recurse -File -Include ('*.yml', '*.yaml')
+    Write-Host "Files found in $($folder): $($files.Length)"
+
+    foreach ($file in $files) {
+        Write-Host "Checking $($file.FullName)"
+
+        $yaml = Get-Content -Path $file.FullName | Out-String
+
+        $yaml = $yaml.Replace('{{', '').Replace('}}', '')
+        $jsonObj = (ConvertFrom-Yaml -Yaml $yaml)
+        $inputKeys = $jsonObj.on.workflow_call.inputs.Keys ?? $jsonObj.inputs.Keys
+
+        foreach ($inputKey in $inputKeys) {
+            if (!($inputKey -ceq $inputKey.ToLower())) {
+                Write-Host “Input variable '$inputKey' contains uppercase characters”
+
+                $isValid = $false
+            }
+        }
+    }
+
+    return $isValid
+}

--- a/.github/actions/github-actions-input-name-validate/action.yaml
+++ b/.github/actions/github-actions-input-name-validate/action.yaml
@@ -21,11 +21,6 @@ inputs:
       Path to the folder to perform input parameter validation on.
       If folder does not exist then validation is not performed.
     required: true
-  fail_on_uppercase_input_params:
-    description: |
-      Determine if the step should fail if input name validation fails.
-    required: false
-    default: "false"
 
 runs:
   using: composite
@@ -43,14 +38,5 @@ runs:
 
         Install-Module -Name PowerShell-Yaml -Force
 
-        . ${{ github.action_path }}/Test-GitHubActionsInputNames.ps1
-        $isValid = Test-GitHubActionsInputNames -FolderPath $folder
-        Write-Host "Is valid: $isValid"
-
-        $shouldFail = ('${{ inputs.fail_on_uppercase_input_params }}' -eq 'true')
-        Write-Host "Should fail: $shouldFail"
-
-        if (-not $isValid -and $shouldFail) {
-            throw 'One or more input parameters contain uppercase characters'
-            exit 1
-        }
+        . ${{ github.action_path }}/Assert-GitHubActionsInputNames.ps1
+        Assert-GitHubActionsInputNames -FolderPath $folder

--- a/.github/actions/github-actions-input-name-validate/action.yaml
+++ b/.github/actions/github-actions-input-name-validate/action.yaml
@@ -13,21 +13,24 @@
 # limitations under the License.
 
 name: Github workflows and actions input name validation
-description: Validate that all input fields in workflows and actions are lowercase.
+description: Validate that all input parameters in workflows and actions are lowercase.
 
 inputs:
   yaml_file_or_folder:
-    description: Path to the folder to perform input field validation on. If folder does not exist then validation is not performed.
+    description: |
+      Path to the folder to perform input parameter validation on.
+      If folder does not exist then validation is not performed.
     required: true
   fail_on_uppercase_input_params:
-    description: Determine if the step should fail if input name validation fails.
+    description: |
+      Determine if the step should fail if input name validation fails.
     required: false
     default: "false"
 
 runs:
   using: composite
   steps:
-    - name: Github input variables should be lowercase
+    - name: Run PowerShell script
       shell: pwsh
       run: |
         $folder = "${{ inputs.yaml_file_or_folder }}"
@@ -38,30 +41,16 @@ runs:
           exit 0
         }
 
-        Install-Module -Name powershell-yaml -Force
-        $files = Get-ChildItem -Path $folder -Recurse -File -Include ('*.yml', '*.yaml')
-        Write-Host "Files found in $($folder): $($files.Length)"
-        $uppercaseVarsFound = $false
+        Install-Module -Name PowerShell-Yaml -Force
 
-        foreach($file in $files) {
-            Write-Host "Checking $($file.FullName)"
-            $yaml = Get-Content -Path $file.FullName | Out-String
-            $yaml = $yaml.Replace('{{', '').Replace('}}', '')
-            $jsonObj = (ConvertFrom-Yaml -Yaml $yaml)
-
-            $inputKeys = $jsonObj.on.workflow_call.inputs.Keys ?? $jsonObj.inputs.Keys
-            foreach($inputKey in $inputKeys) {
-                if (!($inputKey -ceq $inputKey.ToLower())) {
-                    Write-Host “Input variable '$inputKey' contains uppercase characters”
-
-                    $uppercaseVarsFound = $true
-                }
-            }
-        }
+        . ${{ github.action_path }}/Test-GitHubActionsInputNames.ps1
+        $isValid = Test-GitHubActionsInputNames -FolderPath $folder
+        Write-Host "Is valid: $isValid"
 
         $shouldFail = ('${{ inputs.fail_on_uppercase_input_params }}' -eq 'true')
-        Write-Host "Should fail step: $shouldFail"
-        if ($uppercaseVarsFound -and $shouldFail) {
-            throw 'One or more input variables contain uppercase characters'
+        Write-Host "Should fail: $shouldFail"
+
+        if (-not $isValid -and $shouldFail) {
+            throw 'One or more input parameters contain uppercase characters'
             exit 1
         }

--- a/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.ps1
+++ b/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.ps1
@@ -1,0 +1,58 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Import-Module PowerShell-Yaml -Force
+
+<#
+    .SYNOPSIS
+    Assert all inputs, outputs and secrets used in DH3 GitHub action and workflow files are valid.
+
+    .DESCRIPTION
+    Assert all inputs, outputs and secrets used in DH3 GitHub action and workflow files are lowercase.
+    It asserts the definitions as well as any usage of the parameters, but only for DH3 custom actions and workflows.
+#>
+function Assert-GitHubActionsCasing {
+    param (
+        # The folder path in which to recursively search for relevant files to validate.
+        [Parameter(Mandatory = $true)]
+        [string]
+        $FolderPath
+    )
+    $isValid = $true
+
+    $files = Get-ChildItem -Path $folder -Recurse -File -Include ('*.yml', '*.yaml')
+    Write-Host "Files found in $($folder): $($files.Length)"
+
+    foreach ($file in $files) {
+        Write-Host "Checking $($file.FullName)"
+
+        $yaml = Get-Content -Path $file.FullName | Out-String
+
+        $yaml = $yaml.Replace('{{', '').Replace('}}', '')
+        $jsonObj = (ConvertFrom-Yaml -Yaml $yaml)
+        $inputKeys = $jsonObj.on.workflow_call.inputs.Keys ?? $jsonObj.inputs.Keys
+
+        foreach ($inputKey in $inputKeys) {
+            if (!($inputKey -ceq $inputKey.ToLower())) {
+                Write-Host “Input variable '$inputKey' contains uppercase characters”
+
+                $isValid = $false
+            }
+        }
+    }
+
+    if (-not $isValid) {
+        throw 'One or more parameters contain uppercase characters'
+    }
+}

--- a/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.ps1
+++ b/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.ps1
@@ -25,7 +25,7 @@ Import-Module PowerShell-Yaml -Force
 function Assert-GitHubActionsCasing {
     param (
         # The folder path in which to recursively search for relevant files to validate.
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]
         $FolderPath
     )

--- a/.github/actions/github-actions-validate-casing/action.yaml
+++ b/.github/actions/github-actions-validate-casing/action.yaml
@@ -1,0 +1,43 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Validate casing in Github workflows and actions
+description: Validate that inputs, outputs and secrets used in DH3 GitHub actions and workflows are lowercase.
+
+inputs:
+  folder:
+    description: |
+      Path to the folder from which to recursively load YAML files and
+      perform casing validation on.
+      If the folder does not exist then validation is not performed.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Run PowerShell script
+      shell: pwsh
+      run: |
+        $folder = "${{ inputs.folder }}"
+
+        if ((Test-Path -Path $folder) -eq $false)
+        {
+          Write-Warning "Skipping casing validation. Folder '$($folder)' not found."
+          exit 0
+        }
+
+        Install-Module -Name PowerShell-Yaml -Force
+
+        . ${{ github.action_path }}/Assert-GitHubActionsCasing.ps1
+        Assert-GitHubActionsCasing -FolderPath $folder

--- a/.github/actions/nuget-get-version-suffix/action.yml
+++ b/.github/actions/nuget-get-version-suffix/action.yml
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 name: Get version suffix for NuGet packages
-description: 'Do not set version suffix if triggered on master/main branch; otherwise set as alpha release with GitHub run number'
+description: "Do not set version suffix if triggered on master/main branch; otherwise set as alpha release with GitHub run number"
 
 outputs:
-  version_suffix_property:
+  version_suffix_PROPERTY:
     description: "Version suffix property for NuGet packages"
     value: ${{ steps.determine_version_suffix.outputs.property }}
 

--- a/.github/actions/nuget-get-version-suffix/action.yml
+++ b/.github/actions/nuget-get-version-suffix/action.yml
@@ -18,7 +18,7 @@ description: "Do not set version suffix if triggered on master/main branch; othe
 outputs:
   version_suffix_PROPERTY: # CONCLUSION: Naming here is case-insensitive
     description: "Version suffix property for NuGet packages"
-    value: ${{ steps.determine_version_suffix.outputs.PROperty }}
+    value: ${{ steps.determine_version_suffix.outputs.PROperty }} # CONCLUSION: Naming here is case-insensitive
 
 runs:
   using: composite
@@ -31,10 +31,10 @@ runs:
         if [[ ${{ env.BRANCH }} == 'master' || ${{ env.BRANCH }} == 'main' ]]
         then
           echo "Empty VersionSuffix"
-          echo "property=''" >>$GITHUB_OUTPUT
+          echo "PROPERTY=''" >>$GITHUB_OUTPUT
         else
           echo "Set VersionSuffix"
-          echo "property=-p:VersionSuffix=-alpha-${{ github.run_number }}" >>$GITHUB_OUTPUT
+          echo "PROPERTY=-p:VersionSuffix=-alpha-${{ github.run_number }}" >>$GITHUB_OUTPUT
         fi
       env:
         BRANCH: ${GITHUB_REF#refs/heads/}

--- a/.github/actions/nuget-get-version-suffix/action.yml
+++ b/.github/actions/nuget-get-version-suffix/action.yml
@@ -16,9 +16,9 @@ name: Get version suffix for NuGet packages
 description: "Do not set version suffix if triggered on master/main branch; otherwise set as alpha release with GitHub run number"
 
 outputs:
-  version_suffix_PROPERTY: # CONCLUSION: Naming here is case-insensitive
+  version_suffix_property:
     description: "Version suffix property for NuGet packages"
-    value: ${{ steps.determine_version_suffix.outputs.PROperty }} # CONCLUSION: Naming here is case-insensitive
+    value: ${{ steps.determine_version_suffix.outputs.property }}
 
 runs:
   using: composite
@@ -31,10 +31,10 @@ runs:
         if [[ ${{ env.BRANCH }} == 'master' || ${{ env.BRANCH }} == 'main' ]]
         then
           echo "Empty VersionSuffix"
-          echo "PROPERTY=''" >>$GITHUB_OUTPUT
+          echo "property=''" >>$GITHUB_OUTPUT
         else
           echo "Set VersionSuffix"
-          echo "PROPERTY=-p:VersionSuffix=-alpha-${{ github.run_number }}" >>$GITHUB_OUTPUT
+          echo "property=-p:VersionSuffix=-alpha-${{ github.run_number }}" >>$GITHUB_OUTPUT
         fi
       env:
         BRANCH: ${GITHUB_REF#refs/heads/}

--- a/.github/actions/nuget-get-version-suffix/action.yml
+++ b/.github/actions/nuget-get-version-suffix/action.yml
@@ -16,9 +16,9 @@ name: Get version suffix for NuGet packages
 description: "Do not set version suffix if triggered on master/main branch; otherwise set as alpha release with GitHub run number"
 
 outputs:
-  version_suffix_PROPERTY:
+  version_suffix_PROPERTY: # CONCLUSION: Naming here is case-insensitive
     description: "Version suffix property for NuGet packages"
-    value: ${{ steps.determine_version_suffix.outputs.property }}
+    value: ${{ steps.determine_version_suffix.outputs.PROperty }}
 
 runs:
   using: composite

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Print output value
         shell: pwsh
         run: |
-          Write-Host "Output: '${{ steps.get_version_suffix.outputs.version_suffix_property }}'"
+          Write-Host "Output: '${{ steps.get_version_suffix.outputs.VERSION_suffix_property }}'"
 
       - name: Validate input fields in .github/workflows folder
         uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@dstenroejl/enhance-input-validation # TODO: Set to v10 before merge

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -174,7 +174,7 @@ jobs:
 
       # TODO: Remove when done testing
       - name: Test use of outputs
-        uses: ./.github/actions/nuget-get-version-suffix
+        uses: Energinet-DataHub/.github/.github/actions/nuget-get-version-suffix@dstenroejl/enhance-input-validation
         id: get_version_suffix
 
       # TODO: Remove when done testing

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -178,6 +178,7 @@ jobs:
         id: get_version_suffix
 
       # TODO: Remove when done testing
+      # CONCLUSION: Usage here is case-insensitive
       - name: Print output value
         shell: pwsh
         run: |

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Print output value
         shell: pwsh
         run: |
-          Write-Host "Output: '${{ steps.get_version_suffix.outputs.VERSION_suffix_property }}'"
+          Write-Host "Output 2: '${{ steps.get_version_suffix.outputs.VERSION_suffix_property }}'"
 
       - name: Validate input fields in .github/workflows folder
         uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@dstenroejl/enhance-input-validation # TODO: Set to v10 before merge

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -173,11 +173,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Validate input fields in .github/workflows folder
-        uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@dstenroejl/enhance-input-validation # TODO: Set to v10 before merge
+        uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@v10
         with:
           yaml_file_or_folder: .github/workflows
 
       - name: Validate input fields in .github/actions folder
-        uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@dstenroejl/enhance-input-validation # TODO: Set to v10 before merge
+        uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@v10
         with:
           yaml_file_or_folder: .github/actions

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -172,6 +172,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      # TODO: Remove when done testing
+      - name: Test use of outputs
+        uses: ./.github/actions/nuget-get-version-suffix
+        id: get_version_suffix
+
+      # TODO: Remove when done testing
+      - name: Print output value
+        shell: pwsh
+        run: |
+          Write-Host "Output: '${{ steps.get_version_suffix.outputs.version_suffix_property }}'"
+
       - name: Validate input fields in .github/workflows folder
         uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@dstenroejl/enhance-input-validation # TODO: Set to v10 before merge
         with:

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -173,13 +173,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Validate input fields in .github/workflows folder
-        uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@v10
+        uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@dstenroejl/enhance-input-validation # TODO: Set to v10 before merge
         with:
           yaml_file_or_folder: .github/workflows
-          fail_on_uppercase_input_params: "true"
 
       - name: Validate input fields in .github/actions folder
-        uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@v10
+        uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@dstenroejl/enhance-input-validation # TODO: Set to v10 before merge
         with:
           yaml_file_or_folder: .github/actions
-          fail_on_uppercase_input_params: "true"

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -172,18 +172,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # TODO: Remove when done testing
-      - name: Test use of outputs
-        uses: Energinet-DataHub/.github/.github/actions/nuget-get-version-suffix@dstenroejl/enhance-input-validation
-        id: get_version_suffix
-
-      # TODO: Remove when done testing
-      # CONCLUSION: Usage here is case-insensitive
-      - name: Print output value
-        shell: pwsh
-        run: |
-          Write-Host "Output 2: '${{ steps.get_version_suffix.outputs.VERSION_suffix_property }}'"
-
       - name: Validate input fields in .github/workflows folder
         uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@dstenroejl/enhance-input-validation # TODO: Set to v10 before merge
         with:

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,7 +15,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           MAJOR_VERSION: 10
-          MINOR_VERSION: 9
+          MINOR_VERSION: 10
           PATCH_VERSION: 0
           REPOSITORY_PATH: "Energinet-DataHub/.github"
         env:


### PR DESCRIPTION
- [x] Refactor `github-actions-input-name-validate` to follow our PowerShell action style and move the script to a PowerShell script (no tests yet).
- [x] Remove unnecessary parameter `fail_on_uppercase_input_params` from `github-actions-input-name-validate`

Reference:
https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/the-outlaws/1014