### PR TITLE
Use new action for validation

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -164,20 +164,20 @@ jobs:
         with:
           yaml_file_or_folder: .github/actions
 
-  github_actions_input_name_validation:
-    name: Input name validation for Github workflows and actions
+  github_actions_validate_casing:
+    name: Validate casing in Github workflows and actions
     if: ${{ inputs.skip_input_name_validation != 'true' }}
     runs-on: ${{ inputs.OPERATING_SYSTEM }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Validate input fields in .github/workflows folder
-        uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@v10
+      - name: Validate casing in custom workflows
+        uses: Energinet-DataHub/.github/.github/actions/github-actions-validate-casing@v10
         with:
-          yaml_file_or_folder: .github/workflows
+          folder: .github/workflows
 
-      - name: Validate input fields in .github/actions folder
-        uses: Energinet-DataHub/.github/.github/actions/github-actions-input-name-validate@v10
+      - name: Validate casing in custom actions
+        uses: Energinet-DataHub/.github/.github/actions/github-actions-validate-casing@v10
         with:
-          yaml_file_or_folder: .github/actions
+          folder: .github/actions

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,7 +15,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           MAJOR_VERSION: 10
-          MINOR_VERSION: 11
+          MINOR_VERSION: 12
           PATCH_VERSION: 0
           REPOSITORY_PATH: "Energinet-DataHub/.github"
         env:


### PR DESCRIPTION
- [x] Use the new (renamed) action from `ci-base` (the old action will be removed in the next PR)

https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/the-outlaws/1014