### PR TITLE
Validate jobs and steps

### DIFF
--- a/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.Tests.ps1
+++ b/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.Tests.ps1
@@ -69,7 +69,7 @@ Describe "When dot-sourcing the script" {
             }
 
             Should -Invoke Write-Host -Times 2 -Exactly -ParameterFilter {
-                $Object -and $Object.StartsWith("Input definition")
+                $Object -and $Object.StartsWith("Action Input definition")
             }
         }
 
@@ -82,7 +82,7 @@ Describe "When dot-sourcing the script" {
             }
 
             Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter {
-                $Object -and $Object.StartsWith("Output definition")
+                $Object -and $Object.StartsWith("Action Output definition")
             }
         }
 
@@ -95,7 +95,7 @@ Describe "When dot-sourcing the script" {
             }
 
             Should -Not -Invoke Write-Host -ParameterFilter {
-                $Object -and $Object.StartsWith("Secret definition")
+                $Object -and $Object.StartsWith("Action Secret definition")
             }
         }
     }
@@ -132,7 +132,7 @@ Describe "When dot-sourcing the script" {
             }
 
             Should -Invoke Write-Host -Times 2 -Exactly -ParameterFilter {
-                $Object -and $Object.StartsWith("Input definition")
+                $Object -and $Object.StartsWith("Workflow Input definition")
             }
         }
 
@@ -145,7 +145,7 @@ Describe "When dot-sourcing the script" {
             }
 
             Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter {
-                $Object -and $Object.StartsWith("Output definition")
+                $Object -and $Object.StartsWith("Workflow Output definition")
             }
         }
 
@@ -158,7 +158,7 @@ Describe "When dot-sourcing the script" {
             }
 
             Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter {
-                $Object -and $Object.StartsWith("Secret definition")
+                $Object -and $Object.StartsWith("Workflow Secret definition")
             }
         }
 
@@ -171,7 +171,7 @@ Describe "When dot-sourcing the script" {
             }
 
             Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter {
-                $Object -and $Object.StartsWith("Workflow dispatch input definition")
+                $Object -and $Object.StartsWith("Workflow Dispatch Input definition")
             }
         }
     }

--- a/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.Tests.ps1
+++ b/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.Tests.ps1
@@ -1,0 +1,178 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Describe "When dot-sourcing the script" {
+    BeforeAll {
+        Install-Module -Name PowerShell-Yaml -Force
+        . $PSScriptRoot/Assert-GitHubActionsCasing.ps1
+
+        Mock Write-Host {}
+    }
+
+    Context "Given Assert-GitHubActionsCasing is called with '<folderPath>'" -ForEach @(
+        @{ FolderPath = "$PSScriptRoot/test-files/actions/action-valid"; ExpectedCount = 1 }
+        @{ FolderPath = "$PSScriptRoot/test-files/actions"; ExpectedCount = 2 }
+        @{ FolderPath = "$PSScriptRoot/test-files"; ExpectedCount = 4 }
+    ) {
+        BeforeAll {
+            Mock Test-GitHubFile {}
+        }
+
+        It "Should find <expectedCount> file(s)" {
+            # Act
+            Assert-GitHubActionsCasing -FolderPath $folderPath
+
+            Should -Invoke Test-GitHubFile -Times $expectedCount -Exactly
+        }
+    }
+
+    Context "Given Assert-GitHubActionsCasing is given valid action file" {
+        BeforeAll {
+            $script:folderPath = "$PSScriptRoot/test-files/actions/action-valid"
+        }
+
+        It "Should not throw" {
+            # Act
+            Assert-GitHubActionsCasing -FolderPath $script:folderPath
+        }
+    }
+
+    Context "Given Assert-GitHubActionsCasing is given invalid action file" {
+        BeforeAll {
+            $script:folderPath = "$PSScriptRoot/test-files/actions/action-invalid"
+        }
+
+        It "Should throw" {
+            # Act
+            {
+                Assert-GitHubActionsCasing -FolderPath $script:folderPath
+            } | Should -Throw 'One or more fields contain uppercase characters'
+        }
+
+        It "Should find 2 invalid input definitions" {
+            # Act
+            try {
+                Assert-GitHubActionsCasing -FolderPath $script:folderPath
+            }
+            catch {
+            }
+
+            Should -Invoke Write-Host -Times 2 -Exactly -ParameterFilter {
+                $Object -and $Object.StartsWith("Input definition")
+            }
+        }
+
+        It "Should find 1 invalid output definition" {
+            # Act
+            try {
+                Assert-GitHubActionsCasing -FolderPath $script:folderPath
+            }
+            catch {
+            }
+
+            Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter {
+                $Object -and $Object.StartsWith("Output definition")
+            }
+        }
+
+        It "Should not find any secret definition" {
+            # Act
+            try {
+                Assert-GitHubActionsCasing -FolderPath $script:folderPath
+            }
+            catch {
+            }
+
+            Should -Not -Invoke Write-Host -ParameterFilter {
+                $Object -and $Object.StartsWith("Secret definition")
+            }
+        }
+    }
+
+    Context "Given Assert-GitHubActionsCasing is given valid workflow file" {
+        BeforeAll {
+            $script:folderPath = "$PSScriptRoot/test-files/workflows/workflow-valid"
+        }
+
+        It "Should not throw" {
+            # Act
+            Assert-GitHubActionsCasing -FolderPath $script:folderPath
+        }
+    }
+
+    Context "Given Assert-GitHubActionsCasing is given invalid workflow file" {
+        BeforeAll {
+            $script:folderPath = "$PSScriptRoot/test-files/workflows/workflow-invalid"
+        }
+
+        It "Should throw" {
+            # Act
+            {
+                Assert-GitHubActionsCasing -FolderPath $script:folderPath
+            } | Should -Throw 'One or more fields contain uppercase characters'
+        }
+
+        It "Should find 2 invalid input definitions" {
+            # Act
+            try {
+                Assert-GitHubActionsCasing -FolderPath $script:folderPath
+            }
+            catch {
+            }
+
+            Should -Invoke Write-Host -Times 2 -Exactly -ParameterFilter {
+                $Object -and $Object.StartsWith("Input definition")
+            }
+        }
+
+        It "Should find 1 invalid output definition" {
+            # Act
+            try {
+                Assert-GitHubActionsCasing -FolderPath $script:folderPath
+            }
+            catch {
+            }
+
+            Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter {
+                $Object -and $Object.StartsWith("Output definition")
+            }
+        }
+
+        It "Should find 1 invalid secret definition" {
+            # Act
+            try {
+                Assert-GitHubActionsCasing -FolderPath $script:folderPath
+            }
+            catch {
+            }
+
+            Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter {
+                $Object -and $Object.StartsWith("Secret definition")
+            }
+        }
+
+        It "Should find 1 invalid workflow dispatch input definition" {
+            # Act
+            try {
+                Assert-GitHubActionsCasing -FolderPath $script:folderPath
+            }
+            catch {
+            }
+
+            Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter {
+                $Object -and $Object.StartsWith("Workflow dispatch input definition")
+            }
+        }
+    }
+}

--- a/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.Tests.ps1
+++ b/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.Tests.ps1
@@ -174,5 +174,57 @@ Describe "When dot-sourcing the script" {
                 $Object -and $Object.StartsWith("Workflow Dispatch Input definition")
             }
         }
+
+        It "Should find 2 invalid job with definitions" {
+            # Act
+            try {
+                Assert-GitHubActionsCasing -FolderPath $script:folderPath
+            }
+            catch {
+            }
+
+            Should -Invoke Write-Host -Times 2 -Exactly -ParameterFilter {
+                $Object -and $Object.StartsWith("Job With definition")
+            }
+        }
+
+        It "Should find 1 invalid job output definition" {
+            # Act
+            try {
+                Assert-GitHubActionsCasing -FolderPath $script:folderPath
+            }
+            catch {
+            }
+
+            Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter {
+                $Object -and $Object.StartsWith("Job Output definition")
+            }
+        }
+
+        It "Should find 2 invalid job secret definitions" {
+            # Act
+            try {
+                Assert-GitHubActionsCasing -FolderPath $script:folderPath
+            }
+            catch {
+            }
+
+            Should -Invoke Write-Host -Times 2 -Exactly -ParameterFilter {
+                $Object -and $Object.StartsWith("Job Secret definition")
+            }
+        }
+
+        It "Should find 1 invalid job step with definition" {
+            # Act
+            try {
+                Assert-GitHubActionsCasing -FolderPath $script:folderPath
+            }
+            catch {
+            }
+
+            Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter {
+                $Object -and $Object.StartsWith("Job Step With definition")
+            }
+        }
     }
 }

--- a/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.Tests.ps1
+++ b/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.Tests.ps1
@@ -86,7 +86,7 @@ Describe "When dot-sourcing the script" {
             }
         }
 
-        It "Should not find any secret definition" {
+        It "Should find 2 invalid step with definitions" {
             # Act
             try {
                 Assert-GitHubActionsCasing -FolderPath $script:folderPath
@@ -94,8 +94,8 @@ Describe "When dot-sourcing the script" {
             catch {
             }
 
-            Should -Not -Invoke Write-Host -ParameterFilter {
-                $Object -and $Object.StartsWith("Action Secret definition")
+            Should -Invoke Write-Host -Times 2 -Exactly -ParameterFilter {
+                $Object -and $Object.StartsWith("Action Step With definition")
             }
         }
     }

--- a/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.ps1
+++ b/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.ps1
@@ -173,6 +173,12 @@ function Add-CompositeActionFailures {
      - workflow_call.inputs
      - workflow_call.secrets
      - workflow_call.outputs
+
+    The following 'jobs' definitions are validated:
+     - with
+     - secrets (list of keys or 'inherit')
+     - outputs
+     - steps.with (inline jobs calling actions)
 #>
 function Add-WorkflowFailures {
     param (
@@ -208,6 +214,43 @@ function Add-WorkflowFailures {
     foreach ($key in $yamlObject.on.workflow_dispatch.inputs.Keys) {
         if (!($key -ceq $key.ToLower())) {
             [void]$Failures.Add(“Workflow Dispatch Input definition '$key' contains uppercase characters”)
+        }
+    }
+
+    foreach ($job in $YamlObject.jobs.Values) {
+        foreach ($key in $job.with.Keys) {
+            if (!($key -ceq $key.ToLower())) {
+                [void]$Failures.Add(“Job With definition '$key' contains uppercase characters”)
+            }
+        }
+
+        foreach ($key in $job.outputs.Keys) {
+            if (!($key -ceq $key.ToLower())) {
+                [void]$Failures.Add(“Job Output definition '$key' contains uppercase characters”)
+            }
+        }
+
+        if ($null -ne $job.secrets) {
+            if ($job.secrets.GetType().Name -eq "Hashtable") {
+                foreach ($key in $job.secrets.Keys) {
+                    if (!($key -ceq $key.ToLower())) {
+                        [void]$Failures.Add(“Job Secret definition '$key' contains uppercase characters”)
+                    }
+                }
+            }
+            else {
+                $value = $job.secrets
+                if (!($value -ceq $value.ToLower())) {
+                    [void]$Failures.Add(“Job Secret definition '$value' contains uppercase characters”)
+                }
+            }
+        }
+
+        # Inline job
+        foreach ($key in $job.steps.with.Keys) {
+            if (!($key -ceq $key.ToLower())) {
+                [void]$Failures.Add(“Job Step With definition '$key' contains uppercase characters”)
+            }
         }
     }
 }

--- a/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.ps1
+++ b/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.ps1
@@ -76,19 +76,17 @@ function Test-GitHubFile {
 
     [Object]$yamlObject = (ConvertFrom-Yaml -Yaml $yaml)
 
-    [boolean] $isValid = $true
+    $failures = @()
     if (Test-CompositeActionYaml -YamlObject $yamlObject) {
         foreach ($key in $yamlObject.inputs.Keys) {
             if (!($key -ceq $key.ToLower())) {
-                Write-Host “Action Input definition '$key' contains uppercase characters”
-                $isValid = $false
+                $failures += “Action Input definition '$key' contains uppercase characters”
             }
         }
 
         foreach ($key in $yamlObject.outputs.Keys) {
             if (!($key -ceq $key.ToLower())) {
-                Write-Host “Action Output definition '$key' contains uppercase characters”
-                $isValid = $false
+                $failures += “Action Output definition '$key' contains uppercase characters”
             }
         }
 
@@ -96,33 +94,34 @@ function Test-GitHubFile {
     elseif (Test-WorkflowYaml -YamlObject $yamlObject) {
         foreach ($key in $yamlObject.on.workflow_call.inputs.Keys) {
             if (!($key -ceq $key.ToLower())) {
-                Write-Host “Workflow Input definition '$key' contains uppercase characters”
-                $isValid = $false
+                $failures += “Workflow Input definition '$key' contains uppercase characters”
             }
         }
 
         foreach ($key in $yamlObject.on.workflow_call.outputs.Keys) {
             if (!($key -ceq $key.ToLower())) {
-                Write-Host “Workflow Output definition '$key' contains uppercase characters”
-                $isValid = $false
+                $failures += “Workflow Output definition '$key' contains uppercase characters”
             }
         }
 
         foreach ($key in $yamlObject.on.workflow_call.secrets.Keys) {
             if (!($key -ceq $key.ToLower())) {
-                Write-Host “Workflow Secret definition '$key' contains uppercase characters”
-                $isValid = $false
+                $failures += “Workflow Secret definition '$key' contains uppercase characters”
             }
         }
 
         foreach ($key in $yamlObject.on.workflow_dispatch.inputs.Keys) {
             if (!($key -ceq $key.ToLower())) {
-                Write-Host “Workflow Dispatch Input definition '$key' contains uppercase characters”
-                $isValid = $false
+                $failures += “Workflow Dispatch Input definition '$key' contains uppercase characters”
             }
         }
     }
 
+    foreach ($failure in $failures) {
+        Write-Host $failure
+    }
+
+    [boolean]$isValid = ($failures.Count -eq 0)
     return $isValid
 }
 

--- a/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.ps1
+++ b/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.ps1
@@ -49,6 +49,17 @@ function Assert-GitHubActionsCasing {
 <#
     .SYNOPSIS
     Test if all field definitions for given GitHub action or workflow file is lowercase.
+
+    .DESCRIPTION
+    For workflows the following definitions are tested:
+     - workflow_dispatch.inputs
+     - workflow_call.inputs
+     - workflow_call.secrets
+     - workflow_call.outputs
+
+    For actions the following definitions are tested:
+     - inputs
+     - outputs
 #>
 function Test-GitHubFile {
     param (

--- a/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.ps1
+++ b/.github/actions/github-actions-validate-casing/Assert-GitHubActionsCasing.ps1
@@ -127,6 +127,9 @@ function Test-WorkflowYaml {
     The following definitions are validated:
      - inputs
      - outputs
+
+    The following 'steps' definitions are validated:
+     - with
 #>
 function Add-CompositeActionFailures {
     param (
@@ -150,6 +153,12 @@ function Add-CompositeActionFailures {
     foreach ($key in $YamlObject.outputs.Keys) {
         if (!($key -ceq $key.ToLower())) {
             [void]$Failures.Add(“Action Output definition '$key' contains uppercase characters”)
+        }
+    }
+
+    foreach ($key in $YamlObject.runs.steps.with.Keys) {
+        if (!($key -ceq $key.ToLower())) {
+            [void]$Failures.Add(“Action Step With definition '$key' contains uppercase characters”)
         }
     }
 }

--- a/.github/actions/github-actions-validate-casing/test-files/actions/action-invalid/action-invalid.yaml
+++ b/.github/actions/github-actions-validate-casing/test-files/actions/action-invalid/action-invalid.yaml
@@ -32,3 +32,10 @@ runs:
         echo ${{ inputs.SECOND_input }}
         # Set outputs
         echo "my_output='output-data'" >>$GITHUB_OUTPUT
+
+    - name: Second step
+      uses: thedoctor0/zip-release@master
+      with:
+        TYPE: zip
+        fileNAME: my_file.zip
+        directory: my_folder

--- a/.github/actions/github-actions-validate-casing/test-files/actions/action-invalid/action-invalid.yaml
+++ b/.github/actions/github-actions-validate-casing/test-files/actions/action-invalid/action-invalid.yaml
@@ -1,0 +1,34 @@
+#
+# Test file for testing casing validation of GitHub actions
+#
+
+name: Invalid action
+description: |
+  This action is used for testing and should be INVALID with respect to
+  casing of inputs and outputs fields.
+
+inputs:
+  first_INPUT:
+    description: First input
+    required: true
+  SECOND_input:
+    description: Second input
+    required: false
+    default: ""
+outputs:
+  first_OUTPUT:
+    description: First output
+    value: ${{ steps.determine_output.outputs.my_output }}
+
+runs:
+  using: composite
+  steps:
+    - name: First step
+      id: determine_output
+      shell: bash
+      run: |
+        # Write inputs
+        echo ${{ inputs.first_INPUT }}
+        echo ${{ inputs.SECOND_input }}
+        # Set outputs
+        echo "my_output='output-data'" >>$GITHUB_OUTPUT

--- a/.github/actions/github-actions-validate-casing/test-files/actions/action-invalid/action-invalid.yaml
+++ b/.github/actions/github-actions-validate-casing/test-files/actions/action-invalid/action-invalid.yaml
@@ -33,7 +33,7 @@ runs:
         # Set outputs
         echo "my_output='output-data'" >>$GITHUB_OUTPUT
 
-    - name: Second step
+    - name: Zip folder
       uses: thedoctor0/zip-release@master
       with:
         TYPE: zip

--- a/.github/actions/github-actions-validate-casing/test-files/actions/action-invalid/action-invalid.yaml
+++ b/.github/actions/github-actions-validate-casing/test-files/actions/action-invalid/action-invalid.yaml
@@ -34,7 +34,7 @@ runs:
         echo "my_output='output-data'" >>$GITHUB_OUTPUT
 
     - name: Zip folder
-      uses: thedoctor0/zip-release@master
+      uses: thedoctor0/zip-release
       with:
         TYPE: zip
         fileNAME: my_file.zip

--- a/.github/actions/github-actions-validate-casing/test-files/actions/action-valid/action-valid.yaml
+++ b/.github/actions/github-actions-validate-casing/test-files/actions/action-valid/action-valid.yaml
@@ -1,0 +1,34 @@
+#
+# Test file for testing casing validation of GitHub actions
+#
+
+name: Valid action
+description: |
+  This action is used for testing and should be VALID with respect to
+  casing of inputs and outputs fields.
+
+inputs:
+  first_input:
+    description: First input
+    required: true
+  second_input:
+    description: Second input
+    required: false
+    default: ""
+outputs:
+  first_output:
+    description: First output
+    value: ${{ steps.determine_output.outputs.my_output }}
+
+runs:
+  using: composite
+  steps:
+    - name: First step
+      id: determine_output
+      shell: bash
+      run: |
+        # Write inputs
+        echo ${{ inputs.first_input }}
+        echo ${{ inputs.second_input }}
+        # Set outputs
+        echo "my_output='output-data'" >>$GITHUB_OUTPUT

--- a/.github/actions/github-actions-validate-casing/test-files/actions/action-valid/action-valid.yaml
+++ b/.github/actions/github-actions-validate-casing/test-files/actions/action-valid/action-valid.yaml
@@ -32,3 +32,10 @@ runs:
         echo ${{ inputs.second_input }}
         # Set outputs
         echo "my_output='output-data'" >>$GITHUB_OUTPUT
+
+    - name: Second step
+      uses: thedoctor0/zip-release@master
+      with:
+        type: zip
+        filename: my_file.zip
+        directory: my_folder

--- a/.github/actions/github-actions-validate-casing/test-files/actions/action-valid/action-valid.yaml
+++ b/.github/actions/github-actions-validate-casing/test-files/actions/action-valid/action-valid.yaml
@@ -33,7 +33,7 @@ runs:
         # Set outputs
         echo "my_output='output-data'" >>$GITHUB_OUTPUT
 
-    - name: Second step
+    - name: Zip folder
       uses: thedoctor0/zip-release@master
       with:
         type: zip

--- a/.github/actions/github-actions-validate-casing/test-files/actions/action-valid/action-valid.yaml
+++ b/.github/actions/github-actions-validate-casing/test-files/actions/action-valid/action-valid.yaml
@@ -34,7 +34,7 @@ runs:
         echo "my_output='output-data'" >>$GITHUB_OUTPUT
 
     - name: Zip folder
-      uses: thedoctor0/zip-release@master
+      uses: thedoctor0/zip-release
       with:
         type: zip
         filename: my_file.zip

--- a/.github/actions/github-actions-validate-casing/test-files/workflows/workflow-invalid/workflow-invalid.yaml
+++ b/.github/actions/github-actions-validate-casing/test-files/workflows/workflow-invalid/workflow-invalid.yaml
@@ -36,7 +36,7 @@ jobs:
     name: Determine magic
     runs-on: ubuntu-latest
     outputs:
-      magic: ${{ steps.filter.outputs.magic }}
+      MAgic: ${{ steps.filter.outputs.magic }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -45,6 +45,22 @@ jobs:
         uses: dorny/paths-filter@v2
         id: filter
         with:
-          filters: |
+          FILTERS: |
             magic:
               - '.github/workflows/magic-*.yml'
+
+  ci_magic_build:
+    needs: changes
+    if: ${{ needs.changes.outputs.magic == 'true' }}
+    uses: ./.github/workflows/ci-magic-build.yml
+    with:
+      SOLUTION_file_path: my.sln
+    secrets: INHERIT
+
+  ci_magic_test:
+    needs: ci_magic_build
+    uses: Energinet-DataHub/.github/.github/workflows/ci-magic-test.yml@v10
+    with:
+      solution_FILE_path: my.sln
+    secrets:
+      secret_URL: my_secret_url

--- a/.github/actions/github-actions-validate-casing/test-files/workflows/workflow-invalid/workflow-invalid.yaml
+++ b/.github/actions/github-actions-validate-casing/test-files/workflows/workflow-invalid/workflow-invalid.yaml
@@ -1,0 +1,50 @@
+#
+# Test file for testing casing validation of GitHub workflows
+#
+
+name: Invalid workflow
+description: |
+  This workflow is used for testing and should be INVALID with respect to
+  casing of inputs, outputs and secrets fields.
+
+on:
+  workflow_call:
+    inputs:
+      first_INPUT:
+        description: First input
+        required: true
+      SECOND_input:
+        description: Second input
+        required: false
+        default: ""
+    outputs:
+      first_OUTPUT:
+        description: First output
+        value: ${{ jobs.changes.outputs.magic }}
+    secrets:
+      FIRST_secret:
+        required: true
+        description: First secret
+  workflow_dispatch:
+    inputs:
+      FIRST_DISPATCH:
+        description: First dispatch input
+        required: false
+
+jobs:
+  changes:
+    name: Determine magic
+    runs-on: ubuntu-latest
+    outputs:
+      magic: ${{ steps.filter.outputs.magic }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Detect file changes
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            magic:
+              - '.github/workflows/magic-*.yml'

--- a/.github/actions/github-actions-validate-casing/test-files/workflows/workflow-valid/workflow-valid.yaml
+++ b/.github/actions/github-actions-validate-casing/test-files/workflows/workflow-valid/workflow-valid.yaml
@@ -48,3 +48,19 @@ jobs:
           filters: |
             magic:
               - '.github/workflows/magic-*.yml'
+
+  ci_magic_build:
+    needs: changes
+    if: ${{ needs.changes.outputs.magic == 'true' }}
+    uses: ./.github/workflows/ci-magic-build.yml
+    with:
+      solution_file_path: my.sln
+    secrets: inherit
+
+  ci_magic_test:
+    needs: ci_magic_build
+    uses: Energinet-DataHub/.github/.github/workflows/ci-magic-test.yml@v10
+    with:
+      solution_file_path: my.sln
+    secrets:
+      secret_url: my_secret_url

--- a/.github/actions/github-actions-validate-casing/test-files/workflows/workflow-valid/workflow-valid.yaml
+++ b/.github/actions/github-actions-validate-casing/test-files/workflows/workflow-valid/workflow-valid.yaml
@@ -1,0 +1,50 @@
+#
+# Test file for testing casing validation of GitHub workflows
+#
+
+name: Valid workflow
+description: |
+  This workflow is used for testing and should be VALID with respect to
+  casing of inputs, outputs and secrets fields.
+
+on:
+  workflow_call:
+    inputs:
+      first_input:
+        description: First input
+        required: true
+      second_input:
+        description: Second input
+        required: false
+        default: ""
+    outputs:
+      first_output:
+        description: First output
+        value: ${{ jobs.changes.outputs.magic }}
+    secrets:
+      first_secret:
+        required: true
+        description: First secret
+  workflow_dispatch:
+    inputs:
+      first_dispatch:
+        description: First dispatch input
+        required: false
+
+jobs:
+  changes:
+    name: Determine magic
+    runs-on: ubuntu-latest
+    outputs:
+      magic: ${{ steps.filter.outputs.magic }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Detect file changes
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            magic:
+              - '.github/workflows/magic-*.yml'

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,7 +15,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           MAJOR_VERSION: 10
-          MINOR_VERSION: 17
+          MINOR_VERSION: 18
           PATCH_VERSION: 0
           REPOSITORY_PATH: "Energinet-DataHub/.github"
         env:

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,7 +15,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           MAJOR_VERSION: 10
-          MINOR_VERSION: 16
+          MINOR_VERSION: 17
           PATCH_VERSION: 0
           REPOSITORY_PATH: "Energinet-DataHub/.github"
         env:

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,7 +15,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           MAJOR_VERSION: 10
-          MINOR_VERSION: 14
+          MINOR_VERSION: 15
           PATCH_VERSION: 0
           REPOSITORY_PATH: "Energinet-DataHub/.github"
         env:

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,7 +15,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           MAJOR_VERSION: 10
-          MINOR_VERSION: 15
+          MINOR_VERSION: 16
           PATCH_VERSION: 0
           REPOSITORY_PATH: "Energinet-DataHub/.github"
         env:


### PR DESCRIPTION
Refactor `github-actions-validate-casing` to validate casing rules for calls to jobs/steps.

Jobs definitions:
- `with`
- `secrets`
- `outputs`

Steps definitions:
- `with`
- ~`outputs`~

https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/the-outlaws/1014