### PR TITLE
Configure yaml lint braces rule

### DIFF
--- a/.github/actions/yaml-lint/.yamllint
+++ b/.github/actions/yaml-lint/.yamllint
@@ -12,7 +12,8 @@ yaml-files:
   - ".yamllint"
 
 rules:
-  braces: enable
+  braces:
+    max-spaces-inside: 1
   brackets: enable
   colons: enable
   commas: enable

--- a/.github/actions/yaml-lint/.yamllint
+++ b/.github/actions/yaml-lint/.yamllint
@@ -13,6 +13,7 @@ yaml-files:
 
 rules:
   braces:
+    min-spaces-inside: 1
     max-spaces-inside: 1
   brackets: enable
   colons: enable

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,7 +15,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           MAJOR_VERSION: 10
-          MINOR_VERSION: 19
+          MINOR_VERSION: 20
           PATCH_VERSION: 0
           REPOSITORY_PATH: "Energinet-DataHub/.github"
         env:


### PR DESCRIPTION
Allow 1 space within braces '{' and '}', eg. `{ something: 1 }`