### PR TITLE
Use v10 instead of v9

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -16,7 +16,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 11
           minor_version: 0
-          patch_version: 0
+          patch_version: 1
           repository_path: Energinet-DataHub/.github
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/promote-prerelease.yml
+++ b/.github/workflows/promote-prerelease.yml
@@ -44,7 +44,7 @@ jobs:
           publish_response=$(curl -X PATCH -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $publish_url -d '{"prerelease":"false","draft":"false","tag_name":"'${{ steps.set_release_name.outputs.release_name }}'"}')
 
       - name: Create _latest release
-        uses: Energinet-DataHub/.github/.github/actions/create-latest-release@v9
+        uses: Energinet-DataHub/.github/.github/actions/create-latest-release@v10
         with:
           repo_token: ${{ github.token }}
           release_name: ${{ steps.set_release_name.outputs.release_name }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ When we implement a breaking change we must create a new major version.
 
 You **MUST** ensure that we do not reference releases of  `.github` and `geh-terraform-modules` about to be deleted before creating a new major version in either of these repositories !
 
-Bonusinfo: This schedule runs every night out of dh3-automation
+> :information: This schedule runs every night out of `dh3-automation`.
 
 ---
 
@@ -46,6 +46,7 @@ When creating a new major version we must handle the following:
     - Delete the previous major version release and tag in GitHub
     - Create a root branch based on the last commit for that version and name it as the previous major version
     - Create a branch policy for this new branch to ensure we use PR's for any changes
+1. Delete older major version branches (e.g. `v8`)
 
 From then on any important maintenance changes to the previous version must be implemented using a PR to the version branch.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ When creating a new major version we must handle the following:
     - Delete the previous major version release and tag in GitHub
     - Create a root branch based on the last commit for that version and name it as the previous major version
     - Create a branch policy for this new branch to ensure we use PR's for any changes
-1. Delete older major version branches (e.g. `v8`)
+1. Delete the now unsupported major version branch, or lock it using its branch policy (e.g. `v8`)
 
 From then on any important maintenance changes to the previous version must be implemented using a PR to the version branch.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ When we implement a breaking change we must create a new major version.
 
 You **MUST** ensure that we do not reference releases of  `.github` and `geh-terraform-modules` about to be deleted before creating a new major version in either of these repositories !
 
-> :information: This schedule runs every night out of `dh3-automation`.
+This schedule runs every night out of `dh3-automation`.
 
 ---
 


### PR DESCRIPTION
After creating new major release for .github we should not use v9 any where.