### PR TITLE
Enforce yaml and actions validation

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -45,18 +45,12 @@ on:
         required: false
         type: string
         description: Set to true to skip YAML linting for Github actions and workflows in repository.
-        default: "true"
-      # TODO: Remove when new parameter 'skip_actions_casing_validation' is in use all over
-      skip_input_name_validation:
-        required: false
-        type: string
-        description: Set to true to skip input name validation for Github actions and workflows in repository.
-        default: "true"
+        default: "false"
       skip_actions_casing_validation:
         required: false
         type: string
         description: Set to true to skip casing validation for Github actions and workflows in repository.
-        default: "true"
+        default: "false"
 
 jobs:
   md_check:

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -167,7 +167,7 @@ jobs:
 
   github_actions_validate_casing:
     name: Validate casing in Github actions and workflows
-    if: ${{ inputs.skip_input_name_validation != 'true' || inputs.skip_actions_casing_validation != 'true' }}
+    if: ${{ inputs.skip_actions_casing_validation != 'true' }}
     runs-on: ${{ inputs.operating_system }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -16,7 +16,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 11
           minor_version: 0
-          patch_version: 1
+          patch_version: 3
           repository_path: Energinet-DataHub/.github
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
MERGE AFTER => https://github.com/Energinet-DataHub/.github/pull/257

Utilize that we have just released a new v11 (major) version and no one is using it yet, so we can make a breaking change and ensure no one by mistake skips YAML linting or validation.