### PR TITLE
Refactor Structurizr workflow

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,7 +15,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 11
-          minor_version: 1
+          minor_version: 2
           patch_version: 0
           repository_path: Energinet-DataHub/.github
         env:

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -15,13 +15,17 @@
 name: Render C4 diagrams using Structurizr Lite
 
 # DESCRIPTION:
-# This workflow is used to render C4 model views in a SINGLE Structurizr DSL file using
+# This workflow is used to render C4 model views in a primary Structurizr DSL file using
 # Structurizr Lite (https://structurizr.com/help/lite). Views are rendered as PNG images.
 #
 # Structurizr Lite loads the DSL information and matching layout information from a pair
 # of files named according to the "Structurizr workspace filename":
 #  - '<structurizr_workspace_filename>.dsl'
 #  - '<structurizr_workspace_filename>.json'
+#
+# The workflow support if the primary DSL file includes another C4 model DSL file. In this
+# case the input parameter 'included_model_filename' should be used to specify the filename
+# of this DSL file.
 #
 # The workflow must be called using 'secrets: inherit' to get access PAT token with `repo`
 # and `workflow` scopes. The accessible secret must be named pat_token_repo_workflow

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -53,7 +53,7 @@ on:
           Specify the filename (without extension) of the included C4 model DSL file.
         required: false
         type: string
-        default: "not-in-use" # Having a default value makes the workflow simpler to develop
+        default: not-in-use # Having a default value makes the workflow simpler to develop
     secrets:
       pat_token_repo_workflow:
         description: PAT token with `repo` and `workflow` scopes to re-trigger workflows if rendered diagrams are pushed

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -43,6 +43,13 @@ on:
         description: Structurizr workspace filename, see https://structurizr.com/share/76352/documentation#workspace-filename.
         required: true
         type: string
+      included_model_filename:
+        description: |
+          Only used if the primary DSL file includes another DSL file.
+          Specify the filename (without extension) of the included C4 model DSL file.
+        required: false
+        type: string
+        default: "not-in-use" # Having a default value makes the workflow simpler to develop
     secrets:
       pat_token_repo_workflow:
         description: PAT token with `repo` and `workflow` scopes to re-trigger workflows if rendered diagrams are pushed
@@ -95,6 +102,7 @@ jobs:
           files: |
             **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.dsl
             **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.json
+            **/docs/diagrams/c4-model/${{ inputs.included_model_filename }}.dsl
 
       - name: Write out any changes to Structurizr files - based on `diagrams-changed`-step
         shell: bash

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -93,8 +93,7 @@ jobs:
         with:
           since_last_remote_commit: true
           files: |
-            **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.dsl
-            **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.json
+            **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.{dsl,json}
 
       - name: Write out any changes to Structurizr files - based on `diagrams-changed`-step
         shell: bash

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -100,7 +100,7 @@ jobs:
           curl https://raw.githubusercontent.com/structurizr/puppeteer/cf6f70da15fb18c038e052c9335970eecd77025a/export-diagrams.js --output export-diagrams.js
 
       - name: Determine if Structurizr files has changed since last pushed commit to the remote branch
-        id: diagrams-changed
+        id: diagrams_changed
         uses: tj-actions/changed-files@v35
         with:
           since_last_remote_commit: true
@@ -109,14 +109,14 @@ jobs:
             **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.json
             **/docs/diagrams/c4-model/${{ inputs.included_model_filename }}.dsl
 
-      - name: Write out any changes to Structurizr files - based on `diagrams-changed`-step
+      - name: Write out any changes to Structurizr files - based on `diagrams_changed`-step
         shell: bash
         run: |
-          echo "Structurizr files has changed: ${{ steps.diagrams-changed.outputs.any_changed }}"
-          echo "List changed files: ${{ steps.diagrams-changed.outputs.all_changed_files }}"
+          echo "Structurizr files has changed: ${{ steps.diagrams_changed.outputs.any_changed }}"
+          echo "List changed files: ${{ steps.diagrams_changed.outputs.all_changed_files }}"
 
       - name: Render diagrams as PNG images
-        if: steps.diagrams-changed.outputs.any_changed == 'true'
+        if: steps.diagrams_changed.outputs.any_changed == 'true'
         shell: bash
         run: |
           cd "${{ env.DIAGRAMS_FOLDER }}"
@@ -130,7 +130,7 @@ jobs:
           mv -f *.png "$foldername/"
 
       - name: Commit PNG images
-        if: steps.diagrams-changed.outputs.any_changed == 'true'
+        if: steps.diagrams_changed.outputs.any_changed == 'true'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Auto generated diagrams

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -58,7 +58,7 @@ jobs:
     services:
       # Structurizr Lite image from Docker Hub, see available tags here: https://hub.docker.com/r/structurizr/lite/tags
       structurizr-lite:
-        image: structurizr/lite:latest
+        image: structurizr/lite:3052
         ports:
           - 8080:8080
         volumes:

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -70,7 +70,7 @@ jobs:
     services:
       # Structurizr Lite image from Docker Hub, see available tags here: https://hub.docker.com/r/structurizr/lite/tags
       structurizr-lite:
-        image: structurizr/lite:3052
+        image: structurizr/lite:latest
         ports:
           - 8080:8080
         volumes:

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
 
+      # Script is available from https://github.com/structurizr/puppeteer
       - name: Prepare export-diagrams script
         shell: bash
         run: |

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -27,11 +27,7 @@ name: Render C4 diagrams using Structurizr Lite
 # case the input parameter 'included_model_filename' should be used to specify the filename
 # of this DSL file.
 #
-# The workflow must be called using 'secrets: inherit' to get access PAT token with `repo`
-# and `workflow` scopes. The accessible secret must be named pat_token_repo_workflow
-# See: https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit
-#
-# The rendered diagrams are committed to the feature branch using the `git-auto-commit-action`-action.
+# The rendered diagrams are committed to the feature branch using the `stefanzweifel/git-auto-commit-action`-action.
 # To avoid an infinite loop of rendered diagrams being committed to the feature branch, the
 # `tj-actions/changed-files`-action is used to determine if the DSL file is changed by the recent
 # push to the remote feature branch.
@@ -55,8 +51,10 @@ on:
         type: string
         default: not-in-use # Having a default value makes the workflow simpler to develop
     secrets:
-      pat_token_repo_workflow:
-        description: PAT token with `repo` and `workflow` scopes to re-trigger workflows if rendered diagrams are pushed
+      pat_token_retrigger_workflow:
+        description: |
+          Used to be able to re-trigger workflows if rendered diagrams are pushed.
+          It must be a PAT token with `repo` and `workflow` scopes.
         required: true
 
 jobs:
@@ -85,7 +83,7 @@ jobs:
           # Repository checkout must be called with a PAT token with `repo` and `workflow` scopes.
           # Otherwise `stefanzweifel/git-auto-commit-action` used later in the workflow won't trigger new workflow runs.
           # Link: https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
-          token: ${{ secrets.pat_token_repo_workflow }}
+          token: ${{ secrets.pat_token_retrigger_workflow }}
 
       - name: Setup node
         uses: actions/setup-node@v3

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -1,0 +1,122 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Render C4 diagrams using Structurizr
+
+# DESCRIPTION:
+# This workflow is used to render C4 model views in a SINGLE Structurizr DSL file given by the
+# Structurizr workspace filename (see https://structurizr.com/share/76352/documentation#workspace-filename).
+#
+# Views are rendered to PNG images using Structurizr Lite.
+#
+# The workflow must be called using 'secrets: inherit' to get access PAT token with `repo`
+# and `workflow` scopes. The accessible secret must be named pat_token_repo_workflow
+# See: https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit
+#
+# The rendered diagrams are committed to the feature branch using the `git-auto-commit-action`-action.
+# To avoid an infinite loop of rendered diagrams being committed to the feature branch, the
+# `tj-actions/changed-files`-action is used to determine if the DSL file is changed by the recent
+# push to the remote feature branch.
+# The `tj-actions/changed-files`-action is called with the `since_last_remote_commit`-property set to `true`.
+# That means if multiple commits are pushed to the remote branch at the same time, all commits will be
+# checked for changes to the DSL file. If `since_last_remote_commit` is false (default value),
+# only the latest commit being pushed is checked - thereby not checking any intermediate commits.
+
+on:
+  workflow_call:
+    inputs:
+      structurizr_workspace_filename:
+        description: Structurizr workspace filename (no file extension), see https://structurizr.com/share/76352/documentation#workspace-filename.
+        required: true
+        type: string
+    secrets:
+      pat_token_repo_workflow:
+        description: PAT token with `repo` and `workflow` scopes to re-trigger workflows if rendered diagrams are pushed
+        required: true
+
+jobs:
+  render_structurizr_diagrams:
+    runs-on: ubuntu-latest
+    env:
+      # Location of Structurizr workspace files (*.dsl, *.json)
+      DIAGRAMS_FOLDER: ${{ github.workspace }}/docs/diagrams/c4-model
+      # The DSL filename with extension
+      DSL_FILENAME: ${{ inputs.structurizr_workspace_filename }}.dsl
+      # Url for Structurizr Lite running in docker
+      DIAGRAMS_PAGE_URL: http://localhost:8080/workspace/diagrams
+    services:
+      # Structurizr Lite image from Docker Hub, see available tags here: https://hub.docker.com/r/structurizr/lite/tags
+      structurizr-lite:
+        image: structurizr/lite:latest
+        ports:
+          - 8080:8080
+        volumes:
+          # Set to the value of the DIAGRAMS_FOLDER (environment variable does not work here)
+          - ${{ github.workspace }}/docs/diagrams/c4-model:/usr/local/structurizr
+        env:
+          STRUCTURIZR_WORKSPACE_FILENAME: ${{ inputs.structurizr_workspace_filename }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # Repository checkout must be called with a PAT token with `repo` and `workflow` scopes.
+          # Otherwise `stefanzweifel/git-auto-commit-action` used later in the workflow won't trigger new workflow runs.
+          # Link: https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
+          token: ${{ secrets.pat_token_repo_workflow }}
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+
+      - name: Prepare export-diagrams script
+        shell: bash
+        run: |
+          cd "${{ env.DIAGRAMS_FOLDER }}"
+          rm -rf */
+          npm i puppeteer
+          curl https://raw.githubusercontent.com/structurizr/puppeteer/cf6f70da15fb18c038e052c9335970eecd77025a/export-diagrams.js --output export-diagrams.js
+
+      - name: Determine if the DSL file has changed since last pushed commit to the remote branch
+        id: diagrams-changed
+        uses: tj-actions/changed-files@v35
+        with:
+          since_last_remote_commit: true
+          files: |
+            ${{ env.DIAGRAMS_FOLDER }}/${{ env.DSL_FILENAME }}
+
+      - name: Write out any changes to the DSL file - based on `diagrams-changed`-step
+        shell: bash
+        run: |
+          echo "DSL file has changed: ${{ steps.diagrams-changed.outputs.any_changed }}"
+          echo "List all the files that have changed (hopefully just one): ${{ steps.diagrams-changed.outputs.all_changed_files }}"
+
+      - name: Render diagrams as PNG images
+        if: steps.diagrams-changed.outputs.any_changed == 'true'
+        shell: bash
+        run: |
+          cd "${{ env.DIAGRAMS_FOLDER }}"
+          set -e
+          echo "Rendering diagram(s) ..."
+          ! node export-diagrams.js ${{ env.DIAGRAMS_PAGE_URL }} png | grep png
+          echo "Rendered diagram(s)"
+          rm *-key.png
+          foldername=${{ inputs.structurizr_workspace_filename }}
+          mkdir "$foldername"
+          mv -f *.png "$foldername/"
+
+      - name: Commit PNG images
+        if: steps.diagrams-changed.outputs.any_changed == 'true'
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Auto generated diagrams
+          file_pattern: ${{ env.DIAGRAMS_FOLDER }}/**/*.png

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -101,7 +101,7 @@ jobs:
           echo "List all the files that have changed (hopefully just one): ${{ steps.diagrams-changed.outputs.all_changed_files }}"
 
       - name: Render diagrams as PNG images
-        #if: steps.diagrams-changed.outputs.any_changed == 'true'
+        if: steps.diagrams-changed.outputs.any_changed == 'true'
         shell: bash
         run: |
           cd "${{ env.DIAGRAMS_FOLDER }}"
@@ -115,7 +115,7 @@ jobs:
           mv -f *.png "$foldername/"
 
       - name: Commit PNG images
-        #if: steps.diagrams-changed.outputs.any_changed == 'true'
+        if: steps.diagrams-changed.outputs.any_changed == 'true'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Auto generated diagrams

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -54,9 +54,7 @@ jobs:
     env:
       # Location of Structurizr workspace files (*.dsl, *.json)
       DIAGRAMS_FOLDER: ${{ github.workspace }}/docs/diagrams/c4-model
-      # The DSL filename with extension
-      DSL_FILENAME: ${{ inputs.structurizr_workspace_filename }}.dsl
-      # Url for Structurizr Lite running in docker
+      # Url for diagrams page in Structurizr Lite, when running in docker
       DIAGRAMS_PAGE_URL: http://localhost:8080/workspace/diagrams
     services:
       # Structurizr Lite image from Docker Hub, see available tags here: https://hub.docker.com/r/structurizr/lite/tags
@@ -89,23 +87,22 @@ jobs:
           npm i puppeteer
           curl https://raw.githubusercontent.com/structurizr/puppeteer/cf6f70da15fb18c038e052c9335970eecd77025a/export-diagrams.js --output export-diagrams.js
 
-      # TODO: Fails over and over, disable for now
-      # - name: Determine if the DSL file has changed since last pushed commit to the remote branch
-      #   id: diagrams-changed
-      #   uses: tj-actions/changed-files@v35
-      #   with:
-      #     since_last_remote_commit: true
-      #     files: |
-      #       ${{ env.DIAGRAMS_FOLDER }}/${{ env.DSL_FILENAME }}
+      - name: Determine if Structurizr files has changed since last pushed commit to the remote branch
+        id: diagrams-changed
+        uses: tj-actions/changed-files@v35
+        with:
+          since_last_remote_commit: true
+          files: |
+            **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.{dsl,json}
 
-      # - name: Write out any changes to the DSL file - based on `diagrams-changed`-step
-      #   shell: bash
-      #   run: |
-      #     echo "DSL file has changed: ${{ steps.diagrams-changed.outputs.any_changed }}"
-      #     echo "List all the files that have changed (hopefully just one): ${{ steps.diagrams-changed.outputs.all_changed_files }}"
+      - name: Write out any changes to Structurizr files - based on `diagrams-changed`-step
+        shell: bash
+        run: |
+          echo "Structurizr files has changed: ${{ steps.diagrams-changed.outputs.any_changed }}"
+          echo "List changed files: ${{ steps.diagrams-changed.outputs.all_changed_files }}"
 
       - name: Render diagrams as PNG images
-        #if: steps.diagrams-changed.outputs.any_changed == 'true'
+        if: steps.diagrams-changed.outputs.any_changed == 'true'
         shell: bash
         run: |
           cd "${{ env.DIAGRAMS_FOLDER }}"
@@ -119,7 +116,7 @@ jobs:
           mv -f *.png "$foldername/"
 
       - name: Commit PNG images
-        #if: steps.diagrams-changed.outputs.any_changed == 'true'
+        if: steps.diagrams-changed.outputs.any_changed == 'true'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Auto generated diagrams

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -62,9 +62,9 @@ jobs:
         ports:
           - 8080:8080
         volumes:
-          # Set to the value of the DIAGRAMS_FOLDER (environment variable does not work here)
-          - ${{ github.workspace }}/docs/diagrams/c4-model:/usr/local/structurizr
+          - ${{ github.workspace }}:/usr/local/structurizr
         env:
+          STRUCTURIZR_WORKSPACE_PATH: /docs/diagrams/c4-model
           STRUCTURIZR_WORKSPACE_FILENAME: ${{ inputs.structurizr_workspace_filename }}
     steps:
       - name: Checkout

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -86,20 +86,19 @@ jobs:
           npm i puppeteer
           curl https://raw.githubusercontent.com/structurizr/puppeteer/cf6f70da15fb18c038e052c9335970eecd77025a/export-diagrams.js --output export-diagrams.js
 
-      # TODO: Fails over and over, disable for now
-      # - name: Determine if the DSL file has changed since last pushed commit to the remote branch
-      #   id: diagrams-changed
-      #   uses: tj-actions/changed-files@v35
-      #   with:
-      #     since_last_remote_commit: true
-      #     files: |
-      #       ${{ env.DIAGRAMS_FOLDER }}/${{ env.DSL_FILENAME }}
+      - name: Determine if the DSL file has changed since last pushed commit to the remote branch
+        id: diagrams-changed
+        uses: tj-actions/changed-files@v35
+        with:
+          since_last_remote_commit: true
+          files: |
+            ${{ env.DIAGRAMS_FOLDER }}/${{ env.DSL_FILENAME }}
 
-      # - name: Write out any changes to the DSL file - based on `diagrams-changed`-step
-      #   shell: bash
-      #   run: |
-      #     echo "DSL file has changed: ${{ steps.diagrams-changed.outputs.any_changed }}"
-      #     echo "List all the files that have changed (hopefully just one): ${{ steps.diagrams-changed.outputs.all_changed_files }}"
+      - name: Write out any changes to the DSL file - based on `diagrams-changed`-step
+        shell: bash
+        run: |
+          echo "DSL file has changed: ${{ steps.diagrams-changed.outputs.any_changed }}"
+          echo "List all the files that have changed (hopefully just one): ${{ steps.diagrams-changed.outputs.all_changed_files }}"
 
       - name: Render diagrams as PNG images
         #if: steps.diagrams-changed.outputs.any_changed == 'true'

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -93,7 +93,8 @@ jobs:
         with:
           since_last_remote_commit: true
           files: |
-            **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.{dsl,json}
+            **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.dsl
+            **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.json
 
       - name: Write out any changes to Structurizr files - based on `diagrams-changed`-step
         shell: bash

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Render C4 diagrams using Structurizr
+name: Render C4 diagrams using Structurizr Lite
 
 # DESCRIPTION:
-# This workflow is used to render C4 model views in a SINGLE Structurizr DSL file given by the
-# Structurizr workspace filename (see https://structurizr.com/share/76352/documentation#workspace-filename).
+# This workflow is used to render C4 model views in a SINGLE Structurizr DSL file using
+# Structurizr Lite (https://structurizr.com/help/lite). Views are rendered as PNG images.
 #
-# Views are rendered to PNG images using Structurizr Lite.
+# Structurizr Lite loads the DSL information and matching layout information from a pair
+# of files named according to the "Structurizr workspace filename":
+#  - '<structurizr_workspace_filename>.dsl'
+#  - '<structurizr_workspace_filename>.json'
 #
 # The workflow must be called using 'secrets: inherit' to get access PAT token with `repo`
 # and `workflow` scopes. The accessible secret must be named pat_token_repo_workflow
@@ -37,7 +40,7 @@ on:
   workflow_call:
     inputs:
       structurizr_workspace_filename:
-        description: Structurizr workspace filename (no file extension), see https://structurizr.com/share/76352/documentation#workspace-filename.
+        description: Structurizr workspace filename, see https://structurizr.com/share/76352/documentation#workspace-filename.
         required: true
         type: string
     secrets:

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -91,7 +91,7 @@ jobs:
         id: diagrams-changed
         uses: tj-actions/changed-files@v35
         with:
-          since_last_remote_commit: true
+          #since_last_remote_commit: true
           files: |
             **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.dsl
             **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.json

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -91,7 +91,7 @@ jobs:
         id: diagrams-changed
         uses: tj-actions/changed-files@v35
         with:
-          #since_last_remote_commit: true
+          since_last_remote_commit: true
           files: |
             **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.dsl
             **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.json

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -86,22 +86,23 @@ jobs:
           npm i puppeteer
           curl https://raw.githubusercontent.com/structurizr/puppeteer/cf6f70da15fb18c038e052c9335970eecd77025a/export-diagrams.js --output export-diagrams.js
 
-      - name: Determine if the DSL file has changed since last pushed commit to the remote branch
-        id: diagrams-changed
-        uses: tj-actions/changed-files@v35
-        with:
-          since_last_remote_commit: true
-          files: |
-            ${{ env.DIAGRAMS_FOLDER }}/${{ env.DSL_FILENAME }}
+      # TODO: Fails over and over, disable for now
+      # - name: Determine if the DSL file has changed since last pushed commit to the remote branch
+      #   id: diagrams-changed
+      #   uses: tj-actions/changed-files@v35
+      #   with:
+      #     since_last_remote_commit: true
+      #     files: |
+      #       ${{ env.DIAGRAMS_FOLDER }}/${{ env.DSL_FILENAME }}
 
-      - name: Write out any changes to the DSL file - based on `diagrams-changed`-step
-        shell: bash
-        run: |
-          echo "DSL file has changed: ${{ steps.diagrams-changed.outputs.any_changed }}"
-          echo "List all the files that have changed (hopefully just one): ${{ steps.diagrams-changed.outputs.all_changed_files }}"
+      # - name: Write out any changes to the DSL file - based on `diagrams-changed`-step
+      #   shell: bash
+      #   run: |
+      #     echo "DSL file has changed: ${{ steps.diagrams-changed.outputs.any_changed }}"
+      #     echo "List all the files that have changed (hopefully just one): ${{ steps.diagrams-changed.outputs.all_changed_files }}"
 
       - name: Render diagrams as PNG images
-        if: steps.diagrams-changed.outputs.any_changed == 'true'
+        #if: steps.diagrams-changed.outputs.any_changed == 'true'
         shell: bash
         run: |
           cd "${{ env.DIAGRAMS_FOLDER }}"
@@ -115,7 +116,7 @@ jobs:
           mv -f *.png "$foldername/"
 
       - name: Commit PNG images
-        if: steps.diagrams-changed.outputs.any_changed == 'true'
+        #if: steps.diagrams-changed.outputs.any_changed == 'true'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Auto generated diagrams

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,8 @@
         "editorconfig.editorconfig",
         "davidanson.vscode-markdownlint",
         "ms-vscode.powershell",
-        "redhat.vscode-yaml"
+        "redhat.vscode-yaml",
+        "github.vscode-github-actions"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": []

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains shared github items such as actions, workflows and much
     - [License and linting validation](#license-and-linting-validation)
     - [.NET build and test](#net-build-and-test)
     - [Notify Team](#notify-team)
-    - [Structurizr](#structurizr-diagrams)
+    - [Structurizr Lite: Render diagrams](#structurizr-lite-render-diagrams)
 
 ## Prepare release
 
@@ -220,36 +220,14 @@ When called with a known `TEAM_NAME` it looks up a corresponding GitHub secret t
 
 The secrets are created as organizational secrets in the Energinet organization, and can be managed by The Outlaws.
 
-### Structurizr diagrams
+### Structurizr Lite: Render diagrams
 
-File: [structurizr.yml](.github/workflows/structurizr.yml)
+File: [structurizr-render-diagrams.yml](.github/workflows/structurizr-render-diagrams.yml)
 
-The workflow renders all views in a Structurizr workspace as `*.png` files (diagrams). The diagrams are placed in a folder defined by `DIAGRAM_FOLDER` combined with the name of the DSL file, and auto-committed to the current branch. E.g. the images generated from a file named `views.dsl` will be placed in `DIAGRAM_FOLDER\views\`.
+Read the documentation in the workflow file, including information about `inputs` and `secrets`.
+
+The workflow renders all views in a Structurizr Lite workspace as `*.png` files (diagrams). The diagrams are placed in a folder defined by `DIAGRAM_FOLDER` combined with the name of the DSL file, and auto-committed to the current branch. E.g. the images generated from a file named `views.dsl` will be placed in `DIAGRAM_FOLDER\views\`.
 
 The implementation uses a Structurizr Lite docker image available at [Docker Hub](https://hub.docker.com/r/structurizr/lite/tags) and a script available at [Structurizr / Puppeteer](https://github.com/structurizr/puppeteer).
 
-**Notice:** In case the redering of diagrams fails, see if a newer docker image.
-
-Inputs:
-
-- dsl: required - comma seperated list of dsl's to render.
-
-Secrets:
-
-- pat_token_repo_workflow: PAT token with `repo` and `workflow` scopes used for the repository checkout.
-
-Example:
-
-``` yml
-name: Render C4 models with Structurizr
-
-on:
-  workflow_call: {}
-
-jobs:
-  render_c4:
-    uses: Energinet-DataHub/.github/.github/workflows/structurizr.yml@v11
-    with:
-      dsl: "docs/diagrams/c4-model/views.dsl"
-    secrets: inherit
-```
+**Notice:** In case the redering of diagrams fails, see if a newer docker image, or newer script, is available.


### PR DESCRIPTION
Refactor workflow:
- [x] Use environment variables to configure Structurizr Lite for loading the correct DSL file and any layouts in the JSON file. Doing so will enable support for `!include` with relative file path, and the use of manual layouts.
- [x] Only support the use of one primary DSL file, which can `!include` up to one other local DSL file. Doing so reduces complexity in the workflow, and makes it easier to correctly detect the changes that should render diagrams.
- [x] Update documentation in the workflow and the ReadMe.md file

Part of:
https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/team-the-outlaws/1102