### PR TITLE
Refactor ci base

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -51,6 +51,11 @@ on:
         type: string
         description: Set to true to skip casing validation for Github actions and workflows in repository.
         default: "false"
+      skip_actions_powershell_verification:
+        required: false
+        type: string
+        description: Set to true to skip executing Pester tests for Github actions in repository.
+        default: "false"
 
 jobs:
   md_check:
@@ -178,8 +183,9 @@ jobs:
         with:
           folder: .github
 
-  powershell_verification:
+  github_actions_powershell_verification:
     name: Run Pester tests in actions-folder
+    if: ${{ inputs.skip_actions_powershell_verification != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -177,3 +177,16 @@ jobs:
         uses: Energinet-DataHub/.github/.github/actions/github-actions-validate-casing@v10
         with:
           folder: .github
+
+  powershell_verification:
+    name: Run Pester tests in actions-folder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run Pester tests
+        shell: pwsh
+        working-directory: .github/actions
+        run: |
+          Invoke-Pester -Output 'Detailed' -CI *.Tests.ps1

--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -11,8 +11,6 @@ jobs:
   #
   ci_base:
     uses: ./.github/workflows/ci-base.yml
-    with:
-      skip_actions_powershell_verification: true
 
   #
   # Automatic Release (verify if release tag exists)

--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -11,9 +11,6 @@ jobs:
   #
   ci_base:
     uses: ./.github/workflows/ci-base.yml
-    with:
-      skip_yaml_lint: false
-      skip_actions_casing_validation: false
 
   #
   # Automatic Release (verify if release tag exists)
@@ -21,22 +18,9 @@ jobs:
   create_release:
     uses: ./.github/workflows/create-release-tag.yml
 
-  powershell_verification:
-    name: Run Pester tests in actions-folder
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Run Pester tests
-        shell: pwsh
-        working-directory: .github/actions
-        run: |
-          Invoke-Pester -Output 'Detailed' -CI *.Tests.ps1
-
   allow_merge_ci_orchestrator:
     runs-on: ubuntu-latest
-    needs: [ci_base, create_release, powershell_verification]
+    needs: [ci_base, create_release]
     if: |
       always()
     steps:

--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -11,6 +11,8 @@ jobs:
   #
   ci_base:
     uses: ./.github/workflows/ci-base.yml
+    with:
+      skip_actions_powershell_verification: true
 
   #
   # Automatic Release (verify if release tag exists)

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,7 +15,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 11
-          minor_version: 5
+          minor_version: 6
           patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub(.*)@v(?<version>.*)


### PR DESCRIPTION
- [x] Update ci-base to run GitHub actions Pester tests

Part of:
https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/team-the-outlaws/1030

Test run where ci-base is executing Pester tests instead of ci-orchestrator:
https://github.com/Energinet-DataHub/.github/actions/runs/5118846960

Test run where running Pester tests was skipped (using input parameter):
https://github.com/Energinet-DataHub/.github/actions/runs/5118738019