### PR TITLE
Disable pester tests (briefly)

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -55,7 +55,7 @@ on:
         required: false
         type: string
         description: Set to true to skip executing Pester tests for Github actions in repository.
-        default: "false"
+        default: "true"
 
 jobs:
   md_check:

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -16,7 +16,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 11
           minor_version: 7
-          patch_version: 0
+          patch_version: 1
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub(.*)@v(?<version>.*)
         env:


### PR DESCRIPTION
The Pester tests step is failing if there is no tests. We have to disable this step for now.