### PR TITLE
Improve CI Base

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Run Pester tests
         shell: pwsh
         run: |
-          $pesterTestFiles = ".github/actions/*.Tests.ps1"
+          $pesterTestFiles = ".github/actions/**/*.Tests.ps1"
           if (Test-Path -Path $pesterTestFiles -PathType leaf) {
             Invoke-Pester -Output 'Detailed' -CI $pesterTestFiles
           }

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -193,6 +193,11 @@ jobs:
 
       - name: Run Pester tests
         shell: pwsh
-        working-directory: .github/actions
         run: |
-          Invoke-Pester -Output 'Detailed' -CI *.Tests.ps1
+          $pesterTestFiles = ".github/actions/*.Tests.ps1"
+          if (Test-Path -Path $pesterTestFiles -PathType leaf) {
+            Invoke-Pester -Output 'Detailed' -CI $pesterTestFiles
+          }
+          else {
+            Write-Host "No Pester test files detected. Skipping Pester execution."
+          }

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -194,9 +194,9 @@ jobs:
       - name: Run Pester tests
         shell: pwsh
         run: |
-          $pesterTestFiles = ".github/actions/**/*.Tests.ps1"
-          if (Test-Path -Path $pesterTestFiles -PathType leaf) {
-            Invoke-Pester -Output 'Detailed' -CI $pesterTestFiles
+          $pesterTestFilesPattern = ".github/actions/**/*.Tests.ps1"
+          if (Test-Path -Path $pesterTestFilesPattern -PathType leaf) {
+            Invoke-Pester -Output 'Detailed' -CI $pesterTestFilesPattern
           }
           else {
             Write-Host "No Pester test files detected. Skipping Pester execution."

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -55,7 +55,7 @@ on:
         required: false
         type: string
         description: Set to true to skip executing Pester tests for Github actions in repository.
-        default: "true"
+        default: "false"
 
 jobs:
   md_check:

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,8 +15,8 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 11
-          minor_version: 7
-          patch_version: 1
+          minor_version: 8
+          patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub(.*)@v(?<version>.*)
         env:


### PR DESCRIPTION
Only run Pester tests if there exists Pester tests files within the "actions" folder.

Test run where ".github/actions" folder exists, but no *.Tests.ps1 files exist:
https://github.com/Energinet-DataHub/dh3-automation/actions/runs/5121348126?pr=108

Test run where ".github/actions" folder does not exist:
https://github.com/Energinet-DataHub/geh-terraform-modules/actions/runs/5121373665?pr=165

Test run where Pester tests exists:
https://github.com/Energinet-DataHub/opengeh-migration/actions/runs/5121499518

https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/team-the-outlaws/1030