### PR TITLE
Rf halfspace/validate version references filter

### DIFF
--- a/.github/actions/github-validate-version-references/Assert-GithubVersionReferences.ps1
+++ b/.github/actions/github-validate-version-references/Assert-GithubVersionReferences.ps1
@@ -149,7 +149,7 @@ function Assert-GithubVersionReferences {
         throw "Error: GH_TOKEN environment variable is not set, see https://cli.github.com/manual/gh_auth_login for details"
     }
 
-    $files = Get-ChildItem -Path $Path -File -Recurse -Force -Depth 15
+    $files = Get-ChildItem -Path $Path -File -Recurse -Force -Depth 15 -Include *.yml, *.yaml, *.tf, *.md
 
     $deprecatedReferenceFound = $false
 

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -16,7 +16,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 12
           minor_version: 2
-          patch_version: 1
+          patch_version: 2
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:


### PR DESCRIPTION
Due to performance reasons filtering is necessary.

Currently limiting to .yml, .yaml, tf and md files.