### PR TITLE
Bumped Azure Functions Core Tools version

### DIFF
--- a/.github/actions/dotnet-setup-and-tools/action.yml
+++ b/.github/actions/dotnet-setup-and-tools/action.yml
@@ -41,7 +41,7 @@ inputs:
   azure_functions_core_tools_version:
     description: Install specified Azure Functions Core Tools version
     required: false
-    default: 4.0.4670
+    default: 4.0.5198
   # SQL LocalDB 2019
   use_sqllocaldb_2019:
     description: Install 2019 version of SQL LocalDB to support testing

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,7 +15,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 12
-          minor_version: 3
+          minor_version: 4
           patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)

--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -140,7 +140,7 @@ jobs:
       # Tool versions
       NODE_VERSION: 16
       AZURITE_VERSION: 3.24.0
-      AZURE_FUNCTIONS_CORE_TOOLS_VERSION: 4.0.4670
+      AZURE_FUNCTIONS_CORE_TOOLS_VERSION: 4.0.5198
       # Necessary to manage Azure resources from automated tests
       AZURE_KEYVAULT_URL: ${{ inputs.azure_keyvault_url }}
       # Necessary to provide B2C information that allows us to retrieve an access token from automated tests

--- a/.github/workflows/dotnet-solution-ci.yml
+++ b/.github/workflows/dotnet-solution-ci.yml
@@ -112,7 +112,7 @@ jobs:
       # Tool versions
       NODE_VERSION: 16
       AZURITE_VERSION: 3.24.0
-      AZURE_FUNCTIONS_CORE_TOOLS_VERSION: 4.0.4670
+      AZURE_FUNCTIONS_CORE_TOOLS_VERSION: 4.0.5198
       # Necessary to manage Azure resources from automated tests
       AZURE_KEYVAULT_URL: ${{ inputs.azure_keyvault_url }}
       # Necessary to provide B2C information that allows us to retrieve an access token from automated tests


### PR DESCRIPTION
Bumped Azure Functions Core Tools version from 4.0.4670 -> 4.0.5198.

Reason:
To make integration tests where e.g., an Event Hub is included, this version bump is required. Otherwise the following error occurs:

`Microsoft.Azure.WebJobs.Extensions.EventHubs: Could not load type 'Microsoft.Azure.WebJobs.ParameterBindingData' from assembly 'Microsoft.Azure.WebJobs`

This bug was discussed in a thread with the [solution ](https://github.com/Azure/azure-sdk-for-net/issues/34467#issuecomment-1496026290) to bump the version. And this resolved the issue, thus, the reason behind this bump.