### PR TITLE
Refactor Structurizr render diagrams

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,8 +15,8 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 12
-          minor_version: 4
-          patch_version: 1
+          minor_version: 5
+          patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           docker pull structurizr/lite
           docker run \
-            -p 8080:8080 \
+            -t \
             -v ${{ github.workspace }}:/usr/local/structurizr \
             -e STRUCTURIZR_WORKSPACE_PATH=/docs/diagrams/c4-model \
             -e STRUCTURIZR_WORKSPACE_FILENAME=${{ inputs.structurizr_workspace_filename }} \

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -85,51 +85,51 @@ jobs:
           # Link: https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
           token: ${{ secrets.pat_token_retrigger_workflow }}
 
-      - name: Setup node
-        uses: actions/setup-node@v3
+      # - name: Setup node
+      #   uses: actions/setup-node@v3
 
-      # Script is available from https://github.com/structurizr/puppeteer
-      - name: Prepare export-diagrams script
-        shell: bash
-        run: |
-          cd "${{ env.DIAGRAMS_FOLDER }}"
-          rm -rf */
-          npm i puppeteer
-          curl https://raw.githubusercontent.com/structurizr/puppeteer/cf6f70da15fb18c038e052c9335970eecd77025a/export-diagrams.js --output export-diagrams.js
+      # # Script is available from https://github.com/structurizr/puppeteer
+      # - name: Prepare export-diagrams script
+      #   shell: bash
+      #   run: |
+      #     cd "${{ env.DIAGRAMS_FOLDER }}"
+      #     rm -rf */
+      #     npm i puppeteer
+      #     curl https://raw.githubusercontent.com/structurizr/puppeteer/cf6f70da15fb18c038e052c9335970eecd77025a/export-diagrams.js --output export-diagrams.js
 
-      - name: Determine if Structurizr files has changed since last pushed commit to the remote branch
-        id: diagrams_changed
-        uses: tj-actions/changed-files@v35
-        with:
-          since_last_remote_commit: true
-          files: |
-            **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.dsl
-            **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.json
-            **/docs/diagrams/c4-model/${{ inputs.included_model_filename }}.dsl
+      # - name: Determine if Structurizr files has changed since last pushed commit to the remote branch
+      #   id: diagrams_changed
+      #   uses: tj-actions/changed-files@v35
+      #   with:
+      #     since_last_remote_commit: true
+      #     files: |
+      #       **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.dsl
+      #       **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.json
+      #       **/docs/diagrams/c4-model/${{ inputs.included_model_filename }}.dsl
 
-      - name: Write out any changes to Structurizr files - based on `diagrams_changed`-step
-        shell: bash
-        run: |
-          echo "Structurizr files has changed: ${{ steps.diagrams_changed.outputs.any_changed }}"
-          echo "List changed files: ${{ steps.diagrams_changed.outputs.all_changed_files }}"
+      # - name: Write out any changes to Structurizr files - based on `diagrams_changed`-step
+      #   shell: bash
+      #   run: |
+      #     echo "Structurizr files has changed: ${{ steps.diagrams_changed.outputs.any_changed }}"
+      #     echo "List changed files: ${{ steps.diagrams_changed.outputs.all_changed_files }}"
 
-      - name: Render diagrams as PNG images
-        if: steps.diagrams_changed.outputs.any_changed == 'true'
-        shell: bash
-        run: |
-          cd "${{ env.DIAGRAMS_FOLDER }}"
-          set -e
-          echo "Rendering diagram(s) ..."
-          ! node export-diagrams.js ${{ env.DIAGRAMS_PAGE_URL }} png | grep png
-          echo "Rendered diagram(s)"
-          rm *-key.png
-          foldername=${{ inputs.structurizr_workspace_filename }}
-          mkdir "$foldername"
-          mv -f *.png "$foldername/"
+      # - name: Render diagrams as PNG images
+      #   if: steps.diagrams_changed.outputs.any_changed == 'true'
+      #   shell: bash
+      #   run: |
+      #     cd "${{ env.DIAGRAMS_FOLDER }}"
+      #     set -e
+      #     echo "Rendering diagram(s) ..."
+      #     ! node export-diagrams.js ${{ env.DIAGRAMS_PAGE_URL }} png | grep png
+      #     echo "Rendered diagram(s)"
+      #     rm *-key.png
+      #     foldername=${{ inputs.structurizr_workspace_filename }}
+      #     mkdir "$foldername"
+      #     mv -f *.png "$foldername/"
 
-      - name: Commit PNG images
-        if: steps.diagrams_changed.outputs.any_changed == 'true'
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Auto generated diagrams
-          file_pattern: ${{ env.DIAGRAMS_FOLDER }}/**/*.png
+      # - name: Commit PNG images
+      #   if: steps.diagrams_changed.outputs.any_changed == 'true'
+      #   uses: stefanzweifel/git-auto-commit-action@v4
+      #   with:
+      #     commit_message: Auto generated diagrams
+      #     file_pattern: ${{ env.DIAGRAMS_FOLDER }}/**/*.png

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -90,6 +90,7 @@ jobs:
         run: |
           docker pull structurizr/lite
           docker run \
+            -d \
             -t \
             -v ${{ github.workspace }}:/usr/local/structurizr \
             -e STRUCTURIZR_WORKSPACE_PATH=/docs/diagrams/c4-model \

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -92,6 +92,7 @@ jobs:
           docker run \
             -d \
             -t \
+            -p 8080:8080 \
             -v ${{ github.workspace }}:/usr/local/structurizr \
             -e STRUCTURIZR_WORKSPACE_PATH=/docs/diagrams/c4-model \
             -e STRUCTURIZR_WORKSPACE_FILENAME=${{ inputs.structurizr_workspace_filename }} \

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -72,9 +72,9 @@ jobs:
         ports:
           - 8080:8080
         volumes:
-          - ${{ github.workspace }}/docs/diagrams:/usr/local/structurizr
+          - ${{ github.workspace }}:/usr/local/structurizr
         env:
-          STRUCTURIZR_WORKSPACE_PATH: /c4-model
+          STRUCTURIZR_WORKSPACE_PATH: /docs/diagrams/c4-model
           STRUCTURIZR_WORKSPACE_FILENAME: ${{ inputs.structurizr_workspace_filename }}
     steps:
       - name: Checkout

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -65,17 +65,17 @@ jobs:
       DIAGRAMS_FOLDER: ${{ github.workspace }}/docs/diagrams/c4-model
       # Url for diagrams page in Structurizr Lite, when running in docker
       DIAGRAMS_PAGE_URL: http://localhost:8080/workspace/diagrams
-    services:
-      # Structurizr Lite image from Docker Hub, see available tags here: https://hub.docker.com/r/structurizr/lite/tags
-      structurizr-lite:
-        image: structurizr/lite:latest
-        ports:
-          - 8080:8080
-        volumes:
-          - ${{ github.workspace }}:/usr/local/structurizr
-        env:
-          STRUCTURIZR_WORKSPACE_PATH: /docs/diagrams/c4-model
-          STRUCTURIZR_WORKSPACE_FILENAME: ${{ inputs.structurizr_workspace_filename }}
+    # services:
+    #   # Structurizr Lite image from Docker Hub, see available tags here: https://hub.docker.com/r/structurizr/lite/tags
+    #   structurizr-lite:
+    #     image: structurizr/lite:latest
+    #     ports:
+    #       - 8080:8080
+    #     volumes:
+    #       - ${{ github.workspace }}:/usr/local/structurizr
+    #     env:
+    #       STRUCTURIZR_WORKSPACE_PATH: /docs/diagrams/c4-model
+    #       STRUCTURIZR_WORKSPACE_FILENAME: ${{ inputs.structurizr_workspace_filename }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -74,7 +74,7 @@ jobs:
         volumes:
           - ${{ github.workspace }}:/usr/local/structurizr
         env:
-          STRUCTURIZR_WORKSPACE_PATH: /Xdocs/diagrams/c4-model
+          STRUCTURIZR_WORKSPACE_PATH: /docs/diagrams/c4-model
           STRUCTURIZR_WORKSPACE_FILENAME: ${{ inputs.structurizr_workspace_filename }}
     steps:
       - name: Checkout

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -90,6 +90,10 @@ jobs:
           echo "Structurizr files has changed: ${{ steps.diagrams_changed.outputs.any_changed }}"
           echo "List changed files: ${{ steps.diagrams_changed.outputs.all_changed_files }}"
 
+      # We experienced issues with using GitHub 'services' to run Structurizr Lite in docker;
+      # it caused an checkout error in the 'greenforce-frontend' repository.
+      # So instead we use an action to run the docker container; that way we can checkout the
+      # repository BEFORE we run Structurizr Lite.
       - name: Prepare Structurizr Lite (docker)
         if: steps.diagrams_changed.outputs.any_changed == 'true'
         shell: bash

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -90,8 +90,6 @@ jobs:
         run: |
           docker pull structurizr/lite
           docker run \
-            -it \
-            --rm \
             -p 8080:8080 \
             -v ${{ github.workspace }}:/usr/local/structurizr \
             -e STRUCTURIZR_WORKSPACE_PATH=/docs/diagrams/c4-model \

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -84,6 +84,7 @@ jobs:
           # Otherwise `stefanzweifel/git-auto-commit-action` used later in the workflow won't trigger new workflow runs.
           # Link: https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
           token: ${{ secrets.pat_token_retrigger_workflow }}
+          clean: false
 
       # - name: Setup node
       #   uses: actions/setup-node@v3

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -74,7 +74,7 @@ jobs:
         volumes:
           - ${{ github.workspace }}:/usr/local/structurizr
         env:
-          STRUCTURIZR_WORKSPACE_PATH: /docs/diagrams/c4-model
+          STRUCTURIZR_WORKSPACE_PATH: /Xdocs/diagrams/c4-model
           STRUCTURIZR_WORKSPACE_FILENAME: ${{ inputs.structurizr_workspace_filename }}
     steps:
       - name: Checkout

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -68,7 +68,7 @@ jobs:
     services:
       # Structurizr Lite image from Docker Hub, see available tags here: https://hub.docker.com/r/structurizr/lite/tags
       structurizr-lite:
-        image: structurizr/lite:3091
+        image: structurizr/lite:latest
         ports:
           - 8080:8080
         volumes:

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -84,7 +84,6 @@ jobs:
           # Otherwise `stefanzweifel/git-auto-commit-action` used later in the workflow won't trigger new workflow runs.
           # Link: https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
           token: ${{ secrets.pat_token_retrigger_workflow }}
-          clean: false
 
       # - name: Setup node
       #   uses: actions/setup-node@v3

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -72,9 +72,9 @@ jobs:
         ports:
           - 8080:8080
         volumes:
-          - ${{ github.workspace }}:/usr/local/structurizr
+          - ${{ github.workspace }}/docs/diagrams:/usr/local/structurizr
         env:
-          STRUCTURIZR_WORKSPACE_PATH: /docs/diagrams/c4-model
+          STRUCTURIZR_WORKSPACE_PATH: /c4-model
           STRUCTURIZR_WORKSPACE_FILENAME: ${{ inputs.structurizr_workspace_filename }}
     steps:
       - name: Checkout

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -65,17 +65,6 @@ jobs:
       DIAGRAMS_FOLDER: ${{ github.workspace }}/docs/diagrams/c4-model
       # Url for diagrams page in Structurizr Lite, when running in docker
       DIAGRAMS_PAGE_URL: http://localhost:8080/workspace/diagrams
-    # services:
-    #   # Structurizr Lite image from Docker Hub, see available tags here: https://hub.docker.com/r/structurizr/lite/tags
-    #   structurizr-lite:
-    #     image: structurizr/lite:latest
-    #     ports:
-    #       - 8080:8080
-    #     volumes:
-    #       - ${{ github.workspace }}:/usr/local/structurizr
-    #     env:
-    #       STRUCTURIZR_WORKSPACE_PATH: /docs/diagrams/c4-model
-    #       STRUCTURIZR_WORKSPACE_FILENAME: ${{ inputs.structurizr_workspace_filename }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -84,31 +73,6 @@ jobs:
           # Otherwise `stefanzweifel/git-auto-commit-action` used later in the workflow won't trigger new workflow runs.
           # Link: https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
           token: ${{ secrets.pat_token_retrigger_workflow }}
-
-      - name: Prepare Structurizr Lite
-        shell: bash
-        run: |
-          docker pull structurizr/lite
-          docker run \
-            -d \
-            -t \
-            -p 8080:8080 \
-            -v ${{ github.workspace }}:/usr/local/structurizr \
-            -e STRUCTURIZR_WORKSPACE_PATH=/docs/diagrams/c4-model \
-            -e STRUCTURIZR_WORKSPACE_FILENAME=${{ inputs.structurizr_workspace_filename }} \
-            structurizr/lite
-
-      - name: Setup node
-        uses: actions/setup-node@v3
-
-      # Script is available from https://github.com/structurizr/puppeteer
-      - name: Prepare export-diagrams script
-        shell: bash
-        run: |
-          cd "${{ env.DIAGRAMS_FOLDER }}"
-          rm -rf */
-          npm i puppeteer
-          curl https://raw.githubusercontent.com/structurizr/puppeteer/cf6f70da15fb18c038e052c9335970eecd77025a/export-diagrams.js --output export-diagrams.js
 
       - name: Determine if Structurizr files has changed since last pushed commit to the remote branch
         id: diagrams_changed
@@ -125,6 +89,35 @@ jobs:
         run: |
           echo "Structurizr files has changed: ${{ steps.diagrams_changed.outputs.any_changed }}"
           echo "List changed files: ${{ steps.diagrams_changed.outputs.all_changed_files }}"
+
+      - name: Prepare Structurizr Lite (docker)
+        if: steps.diagrams_changed.outputs.any_changed == 'true'
+        shell: bash
+        run: |
+          # Structurizr Lite image from Docker Hub, see available tags here: https://hub.docker.com/r/structurizr/lite/tags
+          docker pull structurizr/lite
+          docker run \
+            -d \
+            -t \
+            -p 8080:8080 \
+            -v ${{ github.workspace }}:/usr/local/structurizr \
+            -e STRUCTURIZR_WORKSPACE_PATH=/docs/diagrams/c4-model \
+            -e STRUCTURIZR_WORKSPACE_FILENAME=${{ inputs.structurizr_workspace_filename }} \
+            structurizr/lite
+
+      - name: Setup node
+        if: steps.diagrams_changed.outputs.any_changed == 'true'
+        uses: actions/setup-node@v3
+
+      # Script is available from https://github.com/structurizr/puppeteer
+      - name: Prepare export-diagrams script
+        if: steps.diagrams_changed.outputs.any_changed == 'true'
+        shell: bash
+        run: |
+          cd "${{ env.DIAGRAMS_FOLDER }}"
+          rm -rf */
+          npm i puppeteer
+          curl https://raw.githubusercontent.com/structurizr/puppeteer/cf6f70da15fb18c038e052c9335970eecd77025a/export-diagrams.js --output export-diagrams.js
 
       - name: Render diagrams as PNG images
         if: steps.diagrams_changed.outputs.any_changed == 'true'

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -65,17 +65,17 @@ jobs:
       DIAGRAMS_FOLDER: ${{ github.workspace }}/docs/diagrams/c4-model
       # Url for diagrams page in Structurizr Lite, when running in docker
       DIAGRAMS_PAGE_URL: http://localhost:8080/workspace/diagrams
-    services:
-      # Structurizr Lite image from Docker Hub, see available tags here: https://hub.docker.com/r/structurizr/lite/tags
-      structurizr-lite:
-        image: structurizr/lite:latest
-        ports:
-          - 8080:8080
-        volumes:
-          - ${{ github.workspace }}:/usr/local/structurizr
-        env:
-          STRUCTURIZR_WORKSPACE_PATH: /docs/diagrams/c4-model
-          STRUCTURIZR_WORKSPACE_FILENAME: ${{ inputs.structurizr_workspace_filename }}
+    # services:
+    #   # Structurizr Lite image from Docker Hub, see available tags here: https://hub.docker.com/r/structurizr/lite/tags
+    #   structurizr-lite:
+    #     image: structurizr/lite:latest
+    #     ports:
+    #       - 8080:8080
+    #     volumes:
+    #       - ${{ github.workspace }}:/usr/local/structurizr
+    #     env:
+    #       STRUCTURIZR_WORKSPACE_PATH: /docs/diagrams/c4-model
+    #       STRUCTURIZR_WORKSPACE_FILENAME: ${{ inputs.structurizr_workspace_filename }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -85,51 +85,64 @@ jobs:
           # Link: https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
           token: ${{ secrets.pat_token_retrigger_workflow }}
 
-      # - name: Setup node
-      #   uses: actions/setup-node@v3
+      - name: Prepare Structurizr Lite
+        shell: bash
+        run: |
+          docker pull structurizr/lite
+          docker run \
+            -it \
+            --rm \
+            -p 8080:8080 \
+            -v ${{ github.workspace }}:/usr/local/structurizr \
+            -e STRUCTURIZR_WORKSPACE_PATH=/docs/diagrams/c4-model \
+            -e STRUCTURIZR_WORKSPACE_FILENAME=${{ inputs.structurizr_workspace_filename }} \
+            structurizr/lite
 
-      # # Script is available from https://github.com/structurizr/puppeteer
-      # - name: Prepare export-diagrams script
-      #   shell: bash
-      #   run: |
-      #     cd "${{ env.DIAGRAMS_FOLDER }}"
-      #     rm -rf */
-      #     npm i puppeteer
-      #     curl https://raw.githubusercontent.com/structurizr/puppeteer/cf6f70da15fb18c038e052c9335970eecd77025a/export-diagrams.js --output export-diagrams.js
+      - name: Setup node
+        uses: actions/setup-node@v3
 
-      # - name: Determine if Structurizr files has changed since last pushed commit to the remote branch
-      #   id: diagrams_changed
-      #   uses: tj-actions/changed-files@v35
-      #   with:
-      #     since_last_remote_commit: true
-      #     files: |
-      #       **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.dsl
-      #       **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.json
-      #       **/docs/diagrams/c4-model/${{ inputs.included_model_filename }}.dsl
+      # Script is available from https://github.com/structurizr/puppeteer
+      - name: Prepare export-diagrams script
+        shell: bash
+        run: |
+          cd "${{ env.DIAGRAMS_FOLDER }}"
+          rm -rf */
+          npm i puppeteer
+          curl https://raw.githubusercontent.com/structurizr/puppeteer/cf6f70da15fb18c038e052c9335970eecd77025a/export-diagrams.js --output export-diagrams.js
 
-      # - name: Write out any changes to Structurizr files - based on `diagrams_changed`-step
-      #   shell: bash
-      #   run: |
-      #     echo "Structurizr files has changed: ${{ steps.diagrams_changed.outputs.any_changed }}"
-      #     echo "List changed files: ${{ steps.diagrams_changed.outputs.all_changed_files }}"
+      - name: Determine if Structurizr files has changed since last pushed commit to the remote branch
+        id: diagrams_changed
+        uses: tj-actions/changed-files@v35
+        with:
+          since_last_remote_commit: true
+          files: |
+            **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.dsl
+            **/docs/diagrams/c4-model/${{ inputs.structurizr_workspace_filename }}.json
+            **/docs/diagrams/c4-model/${{ inputs.included_model_filename }}.dsl
 
-      # - name: Render diagrams as PNG images
-      #   if: steps.diagrams_changed.outputs.any_changed == 'true'
-      #   shell: bash
-      #   run: |
-      #     cd "${{ env.DIAGRAMS_FOLDER }}"
-      #     set -e
-      #     echo "Rendering diagram(s) ..."
-      #     ! node export-diagrams.js ${{ env.DIAGRAMS_PAGE_URL }} png | grep png
-      #     echo "Rendered diagram(s)"
-      #     rm *-key.png
-      #     foldername=${{ inputs.structurizr_workspace_filename }}
-      #     mkdir "$foldername"
-      #     mv -f *.png "$foldername/"
+      - name: Write out any changes to Structurizr files - based on `diagrams_changed`-step
+        shell: bash
+        run: |
+          echo "Structurizr files has changed: ${{ steps.diagrams_changed.outputs.any_changed }}"
+          echo "List changed files: ${{ steps.diagrams_changed.outputs.all_changed_files }}"
 
-      # - name: Commit PNG images
-      #   if: steps.diagrams_changed.outputs.any_changed == 'true'
-      #   uses: stefanzweifel/git-auto-commit-action@v4
-      #   with:
-      #     commit_message: Auto generated diagrams
-      #     file_pattern: ${{ env.DIAGRAMS_FOLDER }}/**/*.png
+      - name: Render diagrams as PNG images
+        if: steps.diagrams_changed.outputs.any_changed == 'true'
+        shell: bash
+        run: |
+          cd "${{ env.DIAGRAMS_FOLDER }}"
+          set -e
+          echo "Rendering diagram(s) ..."
+          ! node export-diagrams.js ${{ env.DIAGRAMS_PAGE_URL }} png | grep png
+          echo "Rendered diagram(s)"
+          rm *-key.png
+          foldername=${{ inputs.structurizr_workspace_filename }}
+          mkdir "$foldername"
+          mv -f *.png "$foldername/"
+
+      - name: Commit PNG images
+        if: steps.diagrams_changed.outputs.any_changed == 'true'
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Auto generated diagrams
+          file_pattern: ${{ env.DIAGRAMS_FOLDER }}/**/*.png

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -65,17 +65,17 @@ jobs:
       DIAGRAMS_FOLDER: ${{ github.workspace }}/docs/diagrams/c4-model
       # Url for diagrams page in Structurizr Lite, when running in docker
       DIAGRAMS_PAGE_URL: http://localhost:8080/workspace/diagrams
-    # services:
-    #   # Structurizr Lite image from Docker Hub, see available tags here: https://hub.docker.com/r/structurizr/lite/tags
-    #   structurizr-lite:
-    #     image: structurizr/lite:latest
-    #     ports:
-    #       - 8080:8080
-    #     volumes:
-    #       - ${{ github.workspace }}:/usr/local/structurizr
-    #     env:
-    #       STRUCTURIZR_WORKSPACE_PATH: /docs/diagrams/c4-model
-    #       STRUCTURIZR_WORKSPACE_FILENAME: ${{ inputs.structurizr_workspace_filename }}
+    services:
+      # Structurizr Lite image from Docker Hub, see available tags here: https://hub.docker.com/r/structurizr/lite/tags
+      structurizr-lite:
+        image: structurizr/lite:3091
+        ports:
+          - 8080:8080
+        volumes:
+          - ${{ github.workspace }}:/usr/local/structurizr
+        env:
+          STRUCTURIZR_WORKSPACE_PATH: /docs/diagrams/c4-model
+          STRUCTURIZR_WORKSPACE_FILENAME: ${{ inputs.structurizr_workspace_filename }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
In the frontend repository the checkout action fails when pulling the "docs" folder. If we don't start docker before the checkout we avoid this issue.

Also change workflow so we only run necessary actions (e.g. if no change do not render diagrams).

Tested in frontend repository PR: https://github.com/Energinet-DataHub/greenforce-frontend/pull/1941
Tested in market participant repository PR (with a reduced views file): https://github.com/Energinet-DataHub/geh-market-participant/pull/591

Related to: https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/team-the-outlaws/1329