### PR TITLE
Log dotnet info

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -16,7 +16,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 12
           minor_version: 11
-          patch_version: 0
+          patch_version: 1
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/dotnet-build-prerelease.yml
+++ b/.github/workflows/dotnet-build-prerelease.yml
@@ -113,6 +113,7 @@ jobs:
           #   The value of 'SourceRevisionId' is appended to the assembly attribute 'InformationalVersion', separated by a '+' sign.
           #   See: https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#generateassemblyinfo
           #
+          dotnet --info
           dotnet build ${{ inputs.solution_file_path }} --no-restore --configuration ${{ env.BUILD_CONFIGURATION }} -p:SourceRevisionId=PR_${{ github.event.number }}+SHA_${{ github.sha }}
 
       # Call action in source (caller) repository


### PR DESCRIPTION
Before calling "dotnet build" we log version information about dotnet so we can determine which .NET SDK version was used, and if any global.json file is used.