### PR TITLE
fix: Set packages permission

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -16,7 +16,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 12
           minor_version: 12
-          patch_version: 1
+          patch_version: 2
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -58,7 +58,7 @@ permissions:
   checks: write # Needed by EnricoMi/publish-unit-test-result-action
   pull-requests: write # Needed by EnricoMi/publish-unit-test-result-action
   #repository-projects: write
-  packages: write # Needed by codecov/codecov-action
+  packages: read # Needed by codecov/codecov-action
 
 
 jobs:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -57,7 +57,9 @@ permissions:
   issues: read # Needed by EnricoMi/publish-unit-test-result-action
   checks: write # Needed by EnricoMi/publish-unit-test-result-action
   pull-requests: write # Needed by EnricoMi/publish-unit-test-result-action
-  repository-projects: write
+  #repository-projects: write
+  packages: write # Needed by codecov/codecov-action
+
 
 jobs:
   python_ci:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -51,13 +51,13 @@ on:
         default: ""
         type: string
 
-# TODO: Revert when done playing around
-# permissions:
-#   id-token: write # Required for use of OIDC in GitHub
-#   contents: read # Required for use of OIDC in GitHub
-#   issues: read # Needed by EnricoMi/publish-unit-test-result-action
-#   checks: write # Needed by EnricoMi/publish-unit-test-result-action
-#   pull-requests: write # Needed by EnricoMi/publish-unit-test-result-action
+permissions:
+  id-token: write # Required for use of OIDC in GitHub
+  contents: read # Required for use of OIDC in GitHub
+  issues: read # Needed by EnricoMi/publish-unit-test-result-action
+  checks: write # Needed by EnricoMi/publish-unit-test-result-action
+  pull-requests: write # Needed by EnricoMi/publish-unit-test-result-action
+  repository-projects: write
 
 jobs:
   python_ci:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -57,9 +57,7 @@ permissions:
   issues: read # Needed by EnricoMi/publish-unit-test-result-action
   checks: write # Needed by EnricoMi/publish-unit-test-result-action
   pull-requests: write # Needed by EnricoMi/publish-unit-test-result-action
-  #repository-projects: write
-  packages: read # Needed by codecov/codecov-action
-
+  packages: read
 
 jobs:
   python_ci:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -51,12 +51,13 @@ on:
         default: ""
         type: string
 
-permissions:
-  id-token: write # Required for use of OIDC in GitHub
-  contents: read # Required for use of OIDC in GitHub
-  issues: read # Needed by EnricoMi/publish-unit-test-result-action
-  checks: write # Needed by EnricoMi/publish-unit-test-result-action
-  pull-requests: write # Needed by EnricoMi/publish-unit-test-result-action
+# TODO: Revert when done playing around
+# permissions:
+#   id-token: write # Required for use of OIDC in GitHub
+#   contents: read # Required for use of OIDC in GitHub
+#   issues: read # Needed by EnricoMi/publish-unit-test-result-action
+#   checks: write # Needed by EnricoMi/publish-unit-test-result-action
+#   pull-requests: write # Needed by EnricoMi/publish-unit-test-result-action
 
 jobs:
   python_ci:


### PR DESCRIPTION
Set packages permission for python-ci.

migrations CI does not works if this is not set.