### PR TITLE
Python CI: Filter for python tests

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,7 +15,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 12
-          minor_version: 13
+          minor_version: 14
           patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -81,6 +81,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        # TODO: Remove checkout of feature branch when done testing
+        with:
+          repository: dstenroejl/python-tests-filter
 
       - name: Static checks
         uses: TrueBrain/actions-flake8@v2

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v3
         # TODO: Remove checkout of feature branch when done testing
         with:
-          repository: dstenroejl/python-tests-filter
+          ref: dstenroejl/python-tests-filter
 
       - name: Static checks
         uses: TrueBrain/actions-flake8@v2

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -81,9 +81,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        # TODO: Remove checkout of feature branch when done testing
-        with:
-          ref: dstenroejl/python-tests-filter
 
       - name: Static checks
         uses: TrueBrain/actions-flake8@v2

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: ubuntu-22.04
         type: string
+      tests_filter_expression:
+        description: Filter expression to use with pytest
+        required: false
+        default: empty
+        type: string
       use_integrationtest_environment:
         description: Set to 'true' to log into Azure for using the integration test environment
         required: false
@@ -92,7 +97,14 @@ jobs:
           subscription-id: ${{ inputs.azure_integrationtest_subscription_id }}
 
       - name: Run unit tests
+        if: ${{ inputs.tests_filter_expression == 'empty' }}
         uses: ./.github/actions/python-unit-test
+
+      - name: Run unit tests with filter
+        if: ${{ inputs.tests_filter_expression != 'empty' }}
+        uses: ./.github/actions/python-unit-test
+        with:
+          tests_filter_expression: ${{ inputs.tests_filter_expression }}
 
       - name: Publish test report
         if: always()

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Features:
 
 - Perform static code analysis of python code (using flake8).
 - Login to Azure using OIDC for accessing the integration test environment from python tests.
-- Execute a custom action to run python tests.
+- Execute a custom action to run python tests. The action can be called with a filter to split the execution of python tests on multiple GitHub runners.
 - Upload test results to workflow summary.
 - Upload test coverage report as workflow artifact and to CodeCov.
 

--- a/README.md
+++ b/README.md
@@ -204,11 +204,11 @@ Features:
 
 - Perform static code analysis of python code (using flake8).
 - Login to Azure using OIDC for accessing the integration test environment from python tests.
-- Execute a custom action to run python tests. The action can be called with a filter to split the execution of python tests on multiple GitHub runners.
+- Execute a custom action to run python tests.
 - Upload test results to workflow summary.
 - Upload test coverage report as workflow artifact and to CodeCov.
 
-The calling repository must have a custom action `python-unit-test` from which the actual execution of `coverage` and `pytest` is performed.
+The calling repository must have a custom action `python-unit-test` from which the actual execution of `coverage` and `pytest` is performed. If the action accepts the input `tests_filter_expression` then it can be called with a filter to split the execution of python tests on multiple GitHub runners.
 
 ### Notify Team
 


### PR DESCRIPTION
Add filter parameter to support filtering which python tests to execute. This allows us to call the workflow multiple time from our repository orchestrator and execute tests in parallel on multiple GitHub runners.