### PR TITLE
Remove CodeCov from shared workflows and actions

### DIFF
--- a/.github/actions/dotnet-solution-build-and-test/action.yml
+++ b/.github/actions/dotnet-solution-build-and-test/action.yml
@@ -18,12 +18,6 @@ description: Build a .NET solution, run tests and upload code coverage
 inputs:
   solution_file_path:
     required: true
-  use_code_coverage:
-    required: false
-    default: "true"
-  code_coverage_flags:
-    required: false
-    default: ""
   build_configuration:
     required: false
     default: Release
@@ -75,11 +69,3 @@ runs:
         comment_mode: failures
         files: |
           **/TestResults/*.trx
-
-    - name: Upload coverage to CodeCov
-      if: ${{ inputs.use_code_coverage == 'true' }}
-      uses: codecov/codecov-action@v3
-      with:
-        flags: ${{ inputs.code_coverage_flags }}
-        fail_ci_if_error: false # Do not fail step when Codecov runs into errors during upload
-        verbose: true

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,8 +15,8 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 12
-          minor_version: 14
-          patch_version: 2
+          minor_version: 15
+          patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -81,10 +81,6 @@ on:
         required: false
         default: false
         type: boolean
-      code_coverage_flags:
-        required: false
-        default: ""
-        type: string
       environment:
         description: Can be used to set environment for OIDC which is AzureAuth
         required: false
@@ -136,7 +132,6 @@ jobs:
 
     env:
       ARTIFACTS_PATH: ${{ github.workspace }}\artifacts
-      TEST_RESULTS_PATH: ${{ github.workspace }}\TestResults
       # Tool versions
       NODE_VERSION: 16
       AZURITE_VERSION: 3.26.0
@@ -309,11 +304,3 @@ jobs:
           comment_mode: failures
           files: |
             **/TestResults/*.trx
-
-      - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@v3
-        with:
-          flags: ${{ inputs.code_coverage_flags }}
-          directory: ${{ env.TEST_RESULTS_PATH }}
-          fail_ci_if_error: false # Do not fail step when Codecov runs into errors during upload
-          verbose: true

--- a/.github/workflows/dotnet-solution-ci.yml
+++ b/.github/workflows/dotnet-solution-ci.yml
@@ -53,10 +53,6 @@ on:
         required: false
         default: false
         type: boolean
-      code_coverage_flags:
-        required: false
-        default: ""
-        type: string
       environment:
         description: Can be used to set environment for OIDC which is AzureAuth
         required: false
@@ -274,13 +270,6 @@ jobs:
         with:
           files: |
             **/TestResults/*.trx
-
-      - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@v3
-        with:
-          flags: ${{ inputs.code_coverage_flags }}
-          fail_ci_if_error: false # Do not fail step when Codecov runs into errors during upload
-          verbose: true
 
       # Call action in source (caller) repository
       - name: Prepare outputs

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -115,4 +115,3 @@ jobs:
           comment_mode: failures
           files: |
             ${{ inputs.test_report_path }}/pytest*.xml
-

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -116,14 +116,3 @@ jobs:
           files: |
             ${{ inputs.test_report_path }}/pytest*.xml
 
-      - name: Upload test coverage report
-        uses: actions/upload-artifact@v3
-        with:
-          name: python-coverage-test-report
-          path: ${{ inputs.test_report_path }}/htmlcov/
-
-      - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: false # Do not fail step when Codecov runs into errors during upload
-          verbose: true

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Features:
 - Login to Azure using OIDC for accessing the integration test environment from python tests.
 - Execute a custom action to run python tests.
 - Upload test results to workflow summary.
-- Upload test coverage report as workflow artifact and to CodeCov.
+- Upload test coverage report as workflow artifact
 
 The calling repository must have a custom action `python-unit-test` from which the actual execution of `coverage` and `pytest` is performed. If the action accepts the input `tests_filter_expression` then it can be called with a filter to split the execution of python tests on multiple GitHub runners.
 


### PR DESCRIPTION
Reference: https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/team-the-outlaws/1813


- [x] [Search for use_code_coverage and code_coverage_flags](https://github.com/search?q=org%3AEnerginet-DataHub+%28code_coverage_flags+OR+use_code_coverage%29&type=code) should only return results from .github repo