### PR TITLE
Allow tools versions as input

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -15,8 +15,8 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 12
-          minor_version: 16
-          patch_version: 1
+          minor_version: 17
+          patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -69,14 +69,32 @@ on:
         default: 12
         type: number
       use_cosmos_db_emulator:
+        description: Install Cosmos DB emulator to support testing
         required: false
         default: false
         type: boolean
+      # Node and modules
       use_azure_functions_tools:
-        description: Use Azurite and Azure Functions Core Tools to support testing
+        description: Install Azurite and Azure Functions Core Tools to support testing
         required: false
         default: false
         type: boolean
+      node_version:
+        description: Install specified Node.js version
+        required: false
+        default: "16"
+        type: string
+      azurite_version:
+        description: Install specified Azurite version
+        required: false
+        default: 3.29.0
+        type: string
+      azure_functions_core_tools_version:
+        description: Install specified Azure Functions Core Tools version
+        required: false
+        default: 4.0.5413
+        type: string
+      # SQL LocalDB 2019
       use_sqllocaldb_2019:
         required: false
         default: false
@@ -132,10 +150,6 @@ jobs:
 
     env:
       ARTIFACTS_PATH: ${{ github.workspace }}\artifacts
-      # Tool versions
-      NODE_VERSION: 16
-      AZURITE_VERSION: 3.29.0
-      AZURE_FUNCTIONS_CORE_TOOLS_VERSION: 4.0.5413
       # Necessary to manage Azure resources from automated tests
       AZURE_KEYVAULT_URL: ${{ inputs.azure_keyvault_url }}
       # Necessary to provide B2C information that allows us to retrieve an access token from automated tests
@@ -190,28 +204,31 @@ jobs:
               Exit 1
             }
 
-      - name: Use Node v${{ env.NODE_VERSION }}
+      - name: Use Node v${{ inputs.node_version }}
         if: ${{ inputs.use_azure_functions_tools == true }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ inputs.node_version }}
 
       - name: Cache node modules
         if: ${{ inputs.use_azure_functions_tools == true }}
         id: cache-nodemodules
         uses: actions/cache@v3
         with:
-          key: ${{ runner.os }}-azurite-${{ env.AZURITE_VERSION }}-func-${{ env.AZURE_FUNCTIONS_CORE_TOOLS_VERSION }}
+          key: ${{ runner.os }}-azurite-${{ inputs.azurite_version }}-func-${{ inputs.azure_functions_core_tools_version }}
           path: ${{ github.workspace }}\node_modules
 
-      - name: Install Azurite v${{ env.AZURITE_VERSION }}
+      - name: Install Azurite v${{ inputs.azurite_version }}
         if: ${{ inputs.use_azure_functions_tools == true && steps.cache-nodemodules.outputs.cache-hit != 'true' }}
+        shell: pwsh
         run: |
-          npm install azurite@${{ env.AZURITE_VERSION }}
+          npm install azurite@${{ inputs.azurite_version }}
 
-      - name: Install Azure Functions Core Tools v${{ env.AZURE_FUNCTIONS_CORE_TOOLS_VERSION }}
+      - name: Install Azure Functions Core Tools v${{ inputs.azure_functions_core_tools_version }}
         if: ${{ inputs.use_azure_functions_tools == true && steps.cache-nodemodules.outputs.cache-hit != 'true' }}
-        run: npm install azure-functions-core-tools@${{ env.AZURE_FUNCTIONS_CORE_TOOLS_VERSION }}
+        shell: pwsh
+        run: |
+          npm install azure-functions-core-tools@${{ inputs.azure_functions_core_tools_version }}
 
       - name: Install SQL LocalDB 2019
         if: ${{ inputs.use_sqllocaldb_2019 == true }}

--- a/.github/workflows/dotnet-solution-ci.yml
+++ b/.github/workflows/dotnet-solution-ci.yml
@@ -36,15 +36,34 @@ on:
         default: windows-2022
         type: string
       use_cosmos_db_emulator:
+        description: Install Cosmos DB emulator to support testing
         required: false
         default: false
         type: boolean
+      # Node and modules
       use_azure_functions_tools:
-        description: Use Azurite and Azure Functions Core Tools to support testing
+        description: Install Azurite and Azure Functions Core Tools to support testing
         required: false
         default: false
         type: boolean
+      node_version:
+        description: Install specified Node.js version
+        required: false
+        default: "16"
+        type: string
+      azurite_version:
+        description: Install specified Azurite version
+        required: false
+        default: 3.29.0
+        type: string
+      azure_functions_core_tools_version:
+        description: Install specified Azure Functions Core Tools version
+        required: false
+        default: 4.0.5413
+        type: string
+      # SQL LocalDB 2019
       use_sqllocaldb_2019:
+        description: Install 2019 version of SQL LocalDB to support testing
         required: false
         default: false
         type: boolean
@@ -105,10 +124,6 @@ jobs:
     env:
       BUILD_CONFIGURATION: Release
       OUTPUT_PATH: ${{ github.workspace }}\output
-      # Tool versions
-      NODE_VERSION: 16
-      AZURITE_VERSION: 3.29.0
-      AZURE_FUNCTIONS_CORE_TOOLS_VERSION: 4.0.5413
       # Necessary to manage Azure resources from automated tests
       AZURE_KEYVAULT_URL: ${{ inputs.azure_keyvault_url }}
       # Necessary to provide B2C information that allows us to retrieve an access token from automated tests
@@ -167,28 +182,31 @@ jobs:
               Exit 1
             }
 
-      - name: Use Node v${{ env.NODE_VERSION }}
+      - name: Use Node v${{ inputs.node_version }}
         if: ${{ inputs.use_azure_functions_tools == true }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ inputs.node_version }}
 
       - name: Cache node modules
         if: ${{ inputs.use_azure_functions_tools == true }}
         id: cache-nodemodules
         uses: actions/cache@v3
         with:
-          key: ${{ runner.os }}-azurite-${{ env.AZURITE_VERSION }}-func-${{ env.AZURE_FUNCTIONS_CORE_TOOLS_VERSION }}
+          key: ${{ runner.os }}-azurite-${{ inputs.azurite_version }}-func-${{ inputs.azure_functions_core_tools_version }}
           path: ${{ github.workspace }}\node_modules
 
-      - name: Install Azurite v${{ env.AZURITE_VERSION }}
+      - name: Install Azurite v${{ inputs.azurite_version }}
         if: ${{ inputs.use_azure_functions_tools == true && steps.cache-nodemodules.outputs.cache-hit != 'true' }}
+        shell: pwsh
         run: |
-          npm install azurite@${{ env.AZURITE_VERSION }}
+          npm install azurite@${{ inputs.azurite_version }}
 
-      - name: Install Azure Functions Core Tools v${{ env.AZURE_FUNCTIONS_CORE_TOOLS_VERSION }}
+      - name: Install Azure Functions Core Tools v${{ inputs.azure_functions_core_tools_version }}
         if: ${{ inputs.use_azure_functions_tools == true && steps.cache-nodemodules.outputs.cache-hit != 'true' }}
-        run: npm install azure-functions-core-tools@${{ env.AZURE_FUNCTIONS_CORE_TOOLS_VERSION }}
+        shell: pwsh
+        run: |
+          npm install azure-functions-core-tools@${{ inputs.azure_functions_core_tools_version }}
 
       - name: Install SQL LocalDB 2019
         if: ${{ inputs.use_sqllocaldb_2019 == true }}


### PR DESCRIPTION
Support setting tools versions as input to allow individual teams to move to another version without forcing other teams to do the same.