### PR TITLE
feat: Configurable python-ci job name

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -22,7 +22,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 13
-          minor_version: 2
+          minor_version: 3
           patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -19,7 +19,7 @@ on:
     inputs:
       job_name:
         required: false
-        default: Python tests
+        default: flake8 and unit test
         type: string
       path_static_checks:
         required: true

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -17,6 +17,10 @@ name: Python CI Test and Coverage
 on:
   workflow_call:
     inputs:
+      job_name:
+        required: false
+        default: Python tests
+        type: string
       path_static_checks:
         required: true
         type: string
@@ -76,7 +80,7 @@ permissions:
 
 jobs:
   python_ci:
-    name: flake8 and unit test
+    name: ${{ inputs.job_name }}
     runs-on: ${{ inputs.operating_system }}
     # Environment is used when using OIDC to login and access the integration test environment
     environment: AzureAuth


### PR DESCRIPTION
This is desired in wholesale where multiple instances of the job are executed, which makes it hard to track.

![image](https://github.com/Energinet-DataHub/.github/assets/11583438/2f68e36d-4817-4721-b6f4-05a853de96d0)

This wholesale test run shows the difference (the 3 flake8 runs above is split into 6 here):
![image](https://github.com/Energinet-DataHub/.github/assets/11583438/be2be0f7-d3d0-485a-ad4d-0c04f56bcff8)
