### PR TITLE
chore: Optimize Azure CLI login for python tests in CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -99,11 +99,9 @@ jobs:
 
       - name: Login to access Azure resources (integration test environment)
         if: ${{ inputs.use_integrationtest_environment == true }}
-        uses: azure/login@v1
-        with:
-          client-id: ${{ inputs.azure_integrationtest_spn_id }}
-          tenant-id: ${{ inputs.azure_integrationtest_tenant_id }}
-          subscription-id: ${{ inputs.azure_integrationtest_subscription_id }}
+        run: |
+          az login --service-principal -u ${{ inputs.azure_integrationtest_spn_id }} --tenant ${{ inputs.azure_integrationtest_tenant_id }}
+          az account set -s ${{ inputs.azure_integrationtest_subscription_id }}
 
       - name: Run unit tests with filter
         uses: Energinet-DataHub/.github/.github/actions/python-unit-test@v13


### PR DESCRIPTION
It's a known issue that the pre and post actions of the Azure CLI login action doesn't respect the conditional: [1.6.0 versions Pre/Post Az CLI login commands need to honor any conditionals on the azure/login · Issue #414 · Azure/login (github.com)](https://github.com/Azure/login/issues/414)
This is a workaround to improve CI execution time while waiting for a solution.