### PR TITLE
Add job_name input parameter

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 13
           minor_version: 9
-          patch_version: 1
+          patch_version: 2
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -34,6 +34,11 @@ name: .NET test
 on:
   workflow_call:
     inputs:
+      job_name:
+        description: Set job name so it is easier to identify job in workflow summary
+        required: false
+        default: .NET CI Test
+        type: string
       tests_dll_file_path:
         description: Relative path from artifacts folder to test assembly
         required: true
@@ -144,6 +149,7 @@ permissions:
 
 jobs:
   dotnet_ci_test:
+    name: ${{ inputs.job_name }}
     runs-on: ${{ inputs.operating_system }}
 
     environment: ${{ inputs.environment }}


### PR DESCRIPTION
Add parameter "job_name" to be able to give each job an unique name from the orchestrator, and thereby making it easier to understand which jobs are running when looking in workflow summary.