### PR TITLE
dotnet: only run specific version install if pinned

### DIFF
--- a/.github/actions/dotnet-setup-and-tools/action.yml
+++ b/.github/actions/dotnet-setup-and-tools/action.yml
@@ -19,7 +19,6 @@ inputs:
   dotnet_version:
     description: Install specified .NET Core SDK version
     required: false
-    default: 8.0.300
   # Cosmos DB emulator
   use_cosmos_db_emulator:
     description: Install Cosmos DB emulator to support testing
@@ -52,6 +51,7 @@ runs:
   using: composite
   steps:
     - name: Setup .NET ${{ inputs.dotnet_version }}
+      if: ${{ inputs.dotnet_version }}
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ inputs.dotnet_version }}

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -22,7 +22,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
-          minor_version: 9
+          minor_version: 10
           patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)

--- a/.github/workflows/dotnet-build-prerelease.yml
+++ b/.github/workflows/dotnet-build-prerelease.yml
@@ -36,7 +36,6 @@ on:
       dotnet_version:
         description: Install specified .NET Core SDK version
         required: false
-        default: 8.0.300
         type: string
       operating_system:
         required: false
@@ -86,6 +85,7 @@ jobs:
           fi
 
       - name: Setup .NET ${{ inputs.dotnet_version }}
+        if: ${{ inputs.dotnet_version }}
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}

--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -61,7 +61,6 @@ on:
       dotnet_version:
         description: Install specified .NET Core SDK version
         required: false
-        default: 8.0.300
         type: string
       operating_system:
         description: Must be a version of Windows, we do not support Linux for testing
@@ -176,6 +175,7 @@ jobs:
           fi
 
       - name: Setup .NET ${{ inputs.dotnet_version }}
+        if: ${{ inputs.dotnet_version }}
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}

--- a/.github/workflows/dotnet-solution-ci.yml
+++ b/.github/workflows/dotnet-solution-ci.yml
@@ -28,7 +28,6 @@ on:
       dotnet_version:
         description: Install specified .NET Core SDK version
         required: false
-        default: 8.0.300
         type: string
       operating_system:
         description: Must be a version of Windows, we do not support Linux for testing
@@ -148,6 +147,7 @@ jobs:
           fi
 
       - name: Setup .NET ${{ inputs.dotnet_version }}
+        if: ${{ inputs.dotnet_version }}
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}


### PR DESCRIPTION
The default github runner already comes with an up-to-date dotnet version. See https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#net-tools

There is no reason for us to manually keep installing a pinned dotnet version. This is adding ~10 seconds extra to each place we use it.

It also gives teams a false sense of security, since they can write whatever they want in the dotnet_version, if they have not locked it with global.json it will always use latest version.

If people want to pin the dotnet_version we still give them this opportunity, but they need to keep in mind, that defining a dotnet_version is not enough, the also need to pin their project to this version using global.json.

Read from the setup-dotnet action below 👇
https://github.com/actions/setup-dotnet?tab=readme-ov-file#usage

`Warning: Unless a concrete version is specified in the [global.json](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json) file, the latest .NET version installed on the runner (including preinstalled versions) will be used [by default](https://learn.microsoft.com/en-us/dotnet/core/versions/selection#the-sdk-uses-the-latest-installed-version). Please refer to the [documentation](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-software) for the currently preinstalled .NET SDK versions.`