### PR TITLE
support custom prerelease prefix databricks

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -22,7 +22,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
-          minor_version: 19
+          minor_version: 20
           patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)

--- a/.github/workflows/databricks-build-prerelease.yml
+++ b/.github/workflows/databricks-build-prerelease.yml
@@ -47,6 +47,10 @@ on:
         required: false
         default: ubuntu-20.04 # Tools for python is not available in arch x64 on 22.04
         type: string
+      prerelease_prefix:
+        required: false
+        type: string
+        default: databricks
 
 jobs:
   create_prerelease:
@@ -54,8 +58,8 @@ jobs:
 
     env:
       RELEASE_FOLDER_PATH: ${{ inputs.wheel_working_directory }}/artifacts
-      RELEASE_VERSION: databricks_${{ github.event.pull_request.number }}
-      RELEASE_ZIP_FILENAME: databricks_${{ github.event.pull_request.number }}.zip
+      RELEASE_VERSION: ${{ inputs.prerelease_prefix }}_${{ github.event.pull_request.number }}
+      RELEASE_ZIP_FILENAME: ${{ inputs.prerelease_prefix }}_${{ github.event.pull_request.number }}.zip
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request includes updates to the GitHub workflows to improve versioning and flexibility in release naming. The most important changes include updating the minor version in the release tag workflow and adding a new input parameter for the prerelease prefix in the Databricks build workflow.

### Versioning updates:

* [`.github/workflows/create-release-tag.yml`](diffhunk://#diff-dd48f7e79b979a8d316ca44ca2cb7466a0b7d2c6acab7e664093e018608f3baeL25-R25): Updated the `minor_version` from 19 to 20 to reflect the new release.

### Flexibility in release naming:

* [`.github/workflows/databricks-build-prerelease.yml`](diffhunk://#diff-5e34523b8d59d6376edd47db8db730c0f061f488c0502e964b21ff7b77695867R50-R62): Added a new input parameter `prerelease_prefix` to allow customization of the release version and zip filename prefixes.