### PR TITLE
Check for push to main in Create-Releasetag

### DIFF
--- a/.github/actions/create-release-tag/Create-ReleaseTag.ps1
+++ b/.github/actions/create-release-tag/Create-ReleaseTag.ps1
@@ -58,8 +58,8 @@ function Create-ReleaseTag {
     )
 
     Write-Host "Github event name is: $GitHubEvent"
-    $isPullRequest = $GitHubEvent -eq 'pull_request'
-    Write-Host "Is PR: $isPullRequest"
+    $isPushToMain = $GitHubEvent -eq 'push' -and $GitHubBranch -eq 'main'
+    Write-Host "Is push to main: $isPushToMain"
 
     $version = "$MajorVersion.$MinorVersion.$PatchVersion"
 
@@ -90,7 +90,7 @@ function Create-ReleaseTag {
     Write-Host "Validated version tag: $version"
 
     # Updating major version tag
-    if (!$isPullRequest) {
+    if ($isPushToMain) {
         Update-VersionTags -Version $version -GitHubRepository $GitHubRepository -GitHubBranch $GitHubBranch
     }
     else {


### PR DESCRIPTION
This pull request includes changes to the `Create-ReleaseTag` function in the `Create-ReleaseTag.ps1` file. The main goal of these changes is to update the conditions under which the version tags are updated to ensure they only occur on pushes to the main branch.

https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/team-the-outlaws/2538

Changes to the `Create-ReleaseTag` function:

* Modified the condition to check if the GitHub event is a push to the main branch instead of a pull request. This ensures that version tags are only updated on pushes to the main branch. [[1]](diffhunk://#diff-ae946b80c66958cdf8136c591606b841a85d88760816b3a94e037d0e13d7b540L61-R62) [[2]](diffhunk://#diff-ae946b80c66958cdf8136c591606b841a85d88760816b3a94e037d0e13d7b540L93-R93)