### PR TITLE
Make user id of github actions runner and docker image identical

### DIFF
--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -27,6 +27,7 @@ runs:
     - name: Execute python tests
       shell: bash
       run: |
+        chmod +x ./.docker/entrypoint.sh
         if [ -n "${{ inputs.tests_folder_path }}" ]; then
           IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
         else

--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -32,7 +32,6 @@ runs:
         repository_owner=${{ github.repository_owner }}
         repository_name=${repository/$repository_owner\//}
 
-        sudo chmod +x ./.docker/entrypoint.sh
         if [ -n "${{ inputs.tests_folder_path }}" ]; then
           IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -w /home/jovyan/work/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
         else

--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -27,13 +27,8 @@ runs:
     - name: Execute python tests
       shell: bash
       run: |
-        # Small hack to get the repository name
-        repository=${{ github.repository }}
-        repository_owner=${{ github.repository_owner }}
-        repository_name=${repository/$repository_owner\//}
-
         if [ -n "${{ inputs.tests_folder_path }}" ]; then
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -w /home/jovyan/work/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
         else
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -w /home/jovyan/work/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
         fi

--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -34,7 +34,7 @@ runs:
 
         sudo chmod +x ./.docker/entrypoint.sh
         if [ -n "${{ inputs.tests_folder_path }}" ]; then
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -w /home/joyvan/work/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -w /home/jovyan/work/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
         else
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -w /home/joyvan/work/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -w /home/jovyan/work/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
         fi

--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -29,7 +29,7 @@ runs:
       run: |
         chmod +x ./.docker/entrypoint.sh
         if [ -n "${{ inputs.tests_folder_path }}" ]; then
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user root --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
         else
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user root --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
         fi

--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -28,6 +28,7 @@ runs:
       shell: bash
       run: |
         chmod +x ./.docker/entrypoint.sh
+        # Execute as user 1001 as that is the user for the GitHub Actions runner
         if [ -n "${{ inputs.tests_folder_path }}" ]; then
           IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
         else

--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -34,7 +34,7 @@ runs:
 
         chmod +x ./.docker/entrypoint.sh
         if [ -n "${{ inputs.tests_folder_path }}" ]; then
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -u root -w //workspaces/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -w //work/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
         else
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -u root -w //workspaces/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -w //work/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
         fi

--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -32,7 +32,7 @@ runs:
         repository_owner=${{ github.repository_owner }}
         repository_name=${repository/$repository_owner\//}
 
-        chmod +x ./.docker/entrypoint.sh
+        sudo chmod +x ./.docker/entrypoint.sh
         if [ -n "${{ inputs.tests_folder_path }}" ]; then
           IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -w /home/joyvan/work/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
         else

--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -29,7 +29,7 @@ runs:
       run: |
         chmod +x ./.docker/entrypoint.sh
         if [ -n "${{ inputs.tests_folder_path }}" ]; then
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --group-add=users --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
         else
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --group-add=users --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
         fi

--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -29,7 +29,7 @@ runs:
       run: |
         chmod +x ./.docker/entrypoint.sh
         if [ -n "${{ inputs.tests_folder_path }}" ]; then
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --group-add=users --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
         else
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --group-add=users --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
         fi

--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -34,7 +34,7 @@ runs:
 
         chmod +x ./.docker/entrypoint.sh
         if [ -n "${{ inputs.tests_folder_path }}" ]; then
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -w //work/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -w /home/joyvan/work/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
         else
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -w //work/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -w /home/joyvan/work/${repository_name} python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
         fi

--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -29,7 +29,7 @@ runs:
       run: |
         chmod +x ./.docker/entrypoint.sh
         if [ -n "${{ inputs.tests_folder_path }}" ]; then
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user root --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
         else
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user root --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
         fi

--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -29,7 +29,7 @@ runs:
       run: |
         chmod +x ./.docker/entrypoint.sh
         if [ -n "${{ inputs.tests_folder_path }}" ]; then
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_folder_path }}" "${{ inputs.tests_filter_expression }}"
         else
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --user 1001 --rm python-unit-test ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"
         fi

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -22,8 +22,8 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
-          minor_version: 21
-          patch_version: 1
+          minor_version: 22
+          patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -110,7 +110,7 @@ jobs:
           subscription-id: ${{ inputs.azure_integrationtest_subscription_id }}
 
       - name: Run unit tests with filter
-        uses: Energinet-DataHub/.github/.github/actions/python-unit-test@v14
+        uses: Energinet-DataHub/.github/.github/actions/python-unit-test@NicolajAaH-patch-1
         with:
           image_tag: ${{ inputs.image_tag }}
           tests_folder_path: ${{ inputs.tests_folder_path}}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -110,7 +110,7 @@ jobs:
           subscription-id: ${{ inputs.azure_integrationtest_subscription_id }}
 
       - name: Run unit tests with filter
-        uses: Energinet-DataHub/.github/.github/actions/python-unit-test@NicolajAaH-patch-1
+        uses: Energinet-DataHub/.github/.github/actions/python-unit-test@v14
         with:
           image_tag: ${{ inputs.image_tag }}
           tests_folder_path: ${{ inputs.tests_folder_path}}


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions configuration files to improve the execution of Python unit tests and to update the release versioning.

This will make sure the user id for the github actions runner is the same as inside the container.


Changes to GitHub Actions configuration:

* [`.github/actions/python-unit-test/action.yml`](diffhunk://#diff-1677fdf35d7f14c02e57a6a3b23538fe3e4f19067b4b4b1d4f838be4ac0e91f7L30-R35): Modified the execution of Python tests to use user ID 1001, which is the user for the GitHub Actions runner.

Versioning updates:

* [`.github/workflows/create-release-tag.yml`](diffhunk://#diff-dd48f7e79b979a8d316ca44ca2cb7466a0b7d2c6acab7e664093e018608f3baeL25-R26): Updated the minor version from 21 to 22 and reset the patch version to 0, reflecting the release of a new minor version.