### PR TITLE
Cache docker images

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
           minor_version: 22
-          patch_version: 1
+          patch_version: 2
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/python-build-and-push-docker-image.yml
+++ b/.github/workflows/python-build-and-push-docker-image.yml
@@ -83,7 +83,7 @@ jobs:
           string: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ${{ env.CONTEXT_PATH }}
           cache-from: type=gha

--- a/.github/workflows/python-build-and-push-docker-image.yml
+++ b/.github/workflows/python-build-and-push-docker-image.yml
@@ -86,5 +86,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ${{ env.CONTEXT_PATH }}
+          cache-from: type=gha
+          cache-to: type=gha
           push: true
           tags: ${{ steps.image-name.outputs.lowercase }}${{ needs.determine_build.outputs.image_tag }}

--- a/.github/workflows/python-build-and-push-docker-image.yml
+++ b/.github/workflows/python-build-and-push-docker-image.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Build
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3


### PR DESCRIPTION
This pull request includes updates to workflow configurations in the `.github/workflows` directory. The changes focus on version updates and caching improvements for Docker builds.

### Workflow Configuration Updates:

* [`.github/workflows/create-release-tag.yml`](diffhunk://#diff-dd48f7e79b979a8d316ca44ca2cb7466a0b7d2c6acab7e664093e018608f3baeL26-R26): Updated the `patch_version` from 1 to 2 to reflect the new release version.

* `.github/workflows/python-build-and-push-docker-image.yml`: 
  - Updated the `docker/setup-buildx-action` to version 3 to use the latest features and improvements.
  - Added caching options `cache-from` and `cache-to` to the `docker/build-push-action` step to improve build efficiency.