### PR TITLE
2629: add cache for nuget packages

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
           minor_version: 22
-          patch_version: 2
+          patch_version: 3
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/dotnet-build-prerelease.yml
+++ b/.github/workflows/dotnet-build-prerelease.yml
@@ -70,26 +70,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Prepare environment variables for OS
-        shell: bash
-        run: |
-          echo "Runner OS is $RUNNER_OS"
-          if [ $RUNNER_OS == 'Linux' ]; then
-            echo "DOTNET_INSTALL_DIR=/usr/share/dotnet" >> $GITHUB_ENV
-          elif [ $RUNNER_OS == 'Windows' ]; then
-            echo "DOTNET_INSTALL_DIR=C:\Program Files\dotnet" >> $GITHUB_ENV
-          else
-            echo "$RUNNER_OS is not supported"
-            exit 1
-          fi
-
       - name: Setup .NET ${{ inputs.dotnet_version }}
         if: ${{ inputs.dotnet_version }}
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
-        env:
-          DOTNET_INSTALL_DIR: ${{ env.DOTNET_INSTALL_DIR }}
 
       - name: Cache NuGet packages
         uses: actions/cache@v4

--- a/.github/workflows/dotnet-build-prerelease.yml
+++ b/.github/workflows/dotnet-build-prerelease.yml
@@ -92,7 +92,6 @@ jobs:
           DOTNET_INSTALL_DIR: ${{ env.DOTNET_INSTALL_DIR }}
 
       - name: Cache NuGet packages
-        if: runner.os == 'Windows'
         uses: actions/cache@v4
         id: cache-nuget
         with:

--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -86,7 +86,7 @@ on:
       node_version:
         description: Install specified Node.js version
         required: false
-        default: "16"
+        default: ""
         type: string
       azurite_version:
         description: Install specified Azurite version
@@ -207,7 +207,7 @@ jobs:
             }
 
       - name: Use Node v${{ inputs.node_version }}
-        if: ${{ inputs.use_azure_functions_tools == true }}
+        if: ${{ inputs.use_azure_functions_tools == true && inputs.node_version != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}

--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -184,13 +184,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
-        env:
-          DOTNET_INSTALL_DIR: C:\Program Files\dotnet
-
-      - uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: ${{ inputs.nuget_cache_key_prefix }}-${{ hashFiles('**/*.csproj') }}
 
       # If the emulator is not started within <timeout> seconds the 'Start-CosmosDbEmulator' timeout.
       # We have added a retry action to see if this can mitigate builds failing on this account.
@@ -291,6 +284,11 @@ jobs:
         shell: pwsh
         run: |
           Expand-Archive '${{ env.ARTIFACTS_PATH }}\dotnet-tests-outputs.zip' '${{ github.workspace }}'
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ inputs.nuget_cache_key_prefix }}-${{ hashFiles('**/*.csproj') }}
 
       # To ensure code coverage tooling is available in bin folders, teams must use 'publish' on test assemblies
       # See https://github.com/coverlet-coverage/coverlet/issues/521#issuecomment-522429394

--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -133,6 +133,11 @@ on:
         required: false
         default: ""
         type: string
+      nuget_cache_key_prefix:
+        description: Prefix for caching NuGet packages
+        required: false
+        type: string
+        default: nuget-${{ inputs.operating_system }}-pr${{ github.event.pull_request.number }}
 
 permissions:
   id-token: write
@@ -181,6 +186,11 @@ jobs:
           dotnet-version: ${{ inputs.dotnet_version }}
         env:
           DOTNET_INSTALL_DIR: C:\Program Files\dotnet
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ inputs.nuget_cache_key_prefix }}-${{ hashFiles('**/*.csproj') }}
 
       # If the emulator is not started within <timeout> seconds the 'Start-CosmosDbEmulator' timeout.
       # We have added a retry action to see if this can mitigate builds failing on this account.


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/dotnet-postbuild-test.yml` file to improve the caching mechanism for NuGet packages.

https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/team-the-outlaws/2629

Enhancements to caching:

* Added a new input parameter `nuget_cache_key_prefix` for specifying a prefix for caching NuGet packages. This helps in creating a unique cache key for different pull requests.
* Integrated the `actions/cache@v4` action to cache NuGet packages using the specified cache key prefix and the hash of `.csproj` files. This should speed up the build process by reusing cached packages.