### PR TITLE
Pin Structurizr to ubuntu 22.04

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
           minor_version: 22
-          patch_version: 3
+          patch_version: 4
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -138,7 +138,7 @@ jobs:
           echo "Rendering diagram(s) ..."
           ! node export-diagrams.js ${{ env.DIAGRAMS_PAGE_URL }} png | grep png
           echo "Rendered diagram(s)"
-          rm *-key.png
+          rm -f *-key.png
           foldername=${{ inputs.structurizr_workspace_filename }}
           mkdir "$foldername"
           mv -f *.png "$foldername/"

--- a/.github/workflows/structurizr-render-diagrams.yml
+++ b/.github/workflows/structurizr-render-diagrams.yml
@@ -65,7 +65,7 @@ on:
 
 jobs:
   render_structurizr_diagrams:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       # Location of Structurizr workspace files (*.dsl, *.json)
       DIAGRAMS_FOLDER: ${{ github.workspace }}/docs/diagrams/c4-model
@@ -138,7 +138,7 @@ jobs:
           echo "Rendering diagram(s) ..."
           ! node export-diagrams.js ${{ env.DIAGRAMS_PAGE_URL }} png | grep png
           echo "Rendered diagram(s)"
-          rm -f *-key.png
+          rm *-key.png
           foldername=${{ inputs.structurizr_workspace_filename }}
           mkdir "$foldername"
           mv -f *.png "$foldername/"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for rendering Structurizr diagrams. The main change is an update to the environment in which the workflow runs.

Environment update:

* [`.github/workflows/structurizr-render-diagrams.yml`](diffhunk://#diff-79161db862a448ba10c9e26f7ed1d4f0eabf0c0a29249c1adf2c25f344a35be6L68-R68): Changed the `runs-on` parameter from `ubuntu-latest` to `ubuntu-22.04`.