### PR TITLE
Add actions for future refactorings toward supporting merge queues

### DIFF
--- a/.github/actions/find-related-pr-number/action.yml
+++ b/.github/actions/find-related-pr-number/action.yml
@@ -14,6 +14,12 @@
 name: Find current pull request
 description: Finds the pull request associated with the current commit.
 
+inputs:
+  debug_enabled:
+    description: Enable debug output
+    required: false
+    default: "false"
+
 outputs:
   pull_request_number:
     description: The pull request number if the pull request was found
@@ -23,6 +29,7 @@ runs:
   using: composite
   steps:
     - name: Print Github context
+      if: ${{ inputs.debug_enabled == 'true' }}
       shell: bash
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}

--- a/.github/actions/github-get-releaseversion-strings/action.yml
+++ b/.github/actions/github-get-releaseversion-strings/action.yml
@@ -1,0 +1,41 @@
+name: Get release version strings
+description: Return release version strings given a release name prefix
+
+inputs:
+  release_name_prefix:
+    description: The release prefix, i.e. 'dotnet'
+    required: true
+  debug_enabled:
+    description: Enable debug output
+    required: false
+    default: "false"
+
+outputs:
+  release_version:
+    description: Release version, i.e. 'dotnet_4711'
+    value: ${{ steps.set_release_version_strings.outputs.release_version }}
+  release_zip_filename:
+    description: Release version ZIP filename, i.e. 'dotnet_4711.zip'
+    value: ${{ steps.set_release_version_strings.outputs.release_zip_filename }}
+
+runs:
+  using: composite
+  steps:
+    - name: Find associated pull request
+      uses: Energinet-DataHub/.github/.github/actions/find-related-pr-number@v14
+      id: find_pull_request
+      with:
+        debug_enabled: ${{ inputs.debug_enabled }}
+
+    - name: Set release version strings
+      id: set_release_version_strings
+      shell: pwsh
+      run: |
+        $releasePrefix = "${{ inputs.release_name_prefix }}"
+        $prNumber = "${{ steps.find_pull_request.outputs.pull_request_number }}"
+        $releaseVersion = "$($releasePrefix)_$($prNumber)"
+        $releaseZipFilename = "$($releasePrefix)_$($prNumber).zip"
+        Write-Host "release_version=$releaseVersion"
+        Write-Host "release_zip_filename=$releaseZipFilename"
+        echo "release_version=$releaseVersion" >> $env:GITHUB_OUTPUT
+        echo "release_zip_filename=$releaseZipFilename" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
These actions are needed to support removing uses of `github.event.pull_request.number` in our workflows