### PR TITLE
Merge queue bugfix - look up PR number using SHA first

### DIFF
--- a/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.Tests.ps1
+++ b/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.Tests.ps1
@@ -7,6 +7,7 @@ Describe "Find-RelatedPullRequestNumber" {
 
     Context 'unknown event' {
         It 'should warn if event could not be recognized' {
+            Mock Invoke-GithubGetPullRequestFromSha { return $null }
             Mock Write-Host { }
             # Looks up PR-number in Github API
             $obj = Find-RelatedPullRequestNumber `

--- a/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.Tests.ps1
+++ b/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.Tests.ps1
@@ -5,8 +5,8 @@ Describe "Find-RelatedPullRequestNumber" {
         $script:Repository = 'myrepo'
     }
 
-    Context 'on pull_request event' {
-        It 'should return PR number' {
+    Context 'pull_request event' {
+        It 'should return PR number when SHA returns PR' {
             Mock Invoke-GithubGetPullRequestFromSha { return '{ "title": "some PR title", "number": "4711" }' | ConvertFrom-Json }
 
             # Looks up PR-number in Github API
@@ -19,13 +19,24 @@ Describe "Find-RelatedPullRequestNumber" {
                 -CommitMessage 'Fancy commit message' `
             | Should -Be '4711'
         }
+
+
+        It 'should throw error when SHA returns null' {
+            Mock Invoke-GithubGetPullRequestFromSha { return $null }
+
+            # Looks up PR-number in Github API
+            { Find-RelatedPullRequestNumber `
+                    -GithubToken $script:GithubToken `
+                    -GithubEvent 'pull_request' `
+                    -Sha 'ab34bed2' `
+                    -GithubRepository $script:Repository `
+                    -RefName '/my/refname' `
+                    -CommitMessage 'Fancy commit message' } | Should -Throw -ExpectedMessage "No pull requests found for sha: ab34bed2"
+        }
     }
-
-    Context 'on merge_group event' {
-        Mock Invoke-GithubGetPullRequestFromSha { return '{ "title": "some PR title"}' | ConvertFrom-Json }
-
-        It 'should return PR number' {
-
+    Context 'merge_group event' {
+        It 'should return PR number from branch name' {
+            Mock Invoke-GithubGetPullRequestFromSha { return '{ "title": "some PR title"}' | ConvertFrom-Json }
             # Gets PR-number from refname
             Find-RelatedPullRequestNumber `
                 -GithubToken $script:GithubToken `
@@ -37,10 +48,15 @@ Describe "Find-RelatedPullRequestNumber" {
             | Should -Be '4711'
         }
     }
-
-    Context 'on push event with valid commit message' {
-        It 'should return PR number' {
-            Mock Invoke-GithubGetPullRequestFromSha { return '{ "title": "some PR title"}' | ConvertFrom-Json }
+    Context 'push event' {
+        It 'should return PR number on push event with valid commit message when SHA returns null' -ForEach @(
+            @{ CommitMessage = "Merge PR to main (#4711)"; Expected = '4711' }
+            @{ CommitMessage = "Merge PR to main"; Expected = $null }
+            @{ CommitMessage = 'Revert "2453: remove deprecated instrumentation key from shared (#2759)" (#2763)'; Expected = '2763' }
+            @{ CommitMessage = "Feat: Add new silver schema (#100) $([System.Environment]::NewLine) Co-authored-by: root <root@TEK-8130.localdomain>"; Expected = '100'
+            }
+        ) {
+            Mock Invoke-GithubGetPullRequestFromSha { return $null }
 
             # Gets PR-number from commit message
             Find-RelatedPullRequestNumber `
@@ -49,39 +65,20 @@ Describe "Find-RelatedPullRequestNumber" {
                 -Sha '1a2b3df4' `
                 -GithubRepository $script:Repository `
                 -RefName 'main' `
-                -CommitMessage 'Merge PR to main (#4711)' `
-            | Should -Be '4711'
-
+                -CommitMessage $CommitMessage `
+            | Should -Be $Expected
         }
-    }
 
-    Context 'on push event with invalid commit message' {
-        It 'should not throw error' {
-            Mock Invoke-GithubGetPullRequestFromSha { return '{ "title": "some PR title"}' | ConvertFrom-Json }
 
-            Find-RelatedPullRequestNumber `
-                -GithubToken $script:GithubToken `
-                -GithubEvent 'push' `
-                -Sha '1a2b3df4' `
-                -GithubRepository $script:Repository `
-                -RefName 'main' `
-                -CommitMessage 'Merge PR to main' `
-            | Should -Be $null
-        }
-    }
 
-    Context 'on push event with commit message containing hyphens' {
-        It 'should not throw error' {
-            Mock Invoke-GithubGetPullRequestFromSha { return '{ "title": "some PR title"}' | ConvertFrom-Json }
-
-            Find-RelatedPullRequestNumber `
-                -GithubToken $script:GithubToken `
-                -GithubEvent 'push' `
-                -Sha '1a2b3df4' `
-                -GithubRepository $script:Repository `
-                -RefName 'main' `
-                -CommitMessage 'Revert "2453: remove deprecated instrumentation key from shared (#2759)" (#2763)' `
-            | Should -Be 2763
+        It 'should return correct PR number' -ForEach @(
+            @{ CommitMessage = "Merge PR to main (#4711)"; Expected = '4711' }
+            @{ CommitMessage = 'Revert "2453: remove deprecated instrumentation key from shared (#2759)" (#2763)'; Expected = '2763' }
+            @{ CommitMessage = "Feat: Add new silver schema (#100) $([System.Environment]::NewLine) Co-authored-by: root <root@TEK-8130.localdomain>"; Expected = '100'
+            }
+        ) {
+            $prNumber = $CommitMessage -match "\(#(\d+)\)(?!.*\(#\d+\))"
+            $Matches[1] | Should -Be $Expected
         }
     }
 }

--- a/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.ps1
+++ b/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.ps1
@@ -106,6 +106,9 @@ function Find-RelatedPullRequestNumber {
                 }
             }
         }
+        default {
+            Write-Host "::warning::Unknown event: $GithubEvent, unable to look up PR"
+        }
     }
     return $prNumber
 }

--- a/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.ps1
+++ b/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.ps1
@@ -51,6 +51,8 @@ function Find-RelatedPullRequestNumber {
     $prNumber = $null
     switch ($GithubEvent) {
         "schedule" {
+            # To be implemented in https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/team-the-outlaws/2770
+
             # If $refname is main, look up PR number using SHA
             # If PR-number is not found, throw error
             # This will fail scheduled workflows with merge queues enabled.

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
           minor_version: 25
-          patch_version: 0
+          patch_version: 1
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:


### PR DESCRIPTION
Always look up using SHA - if PR-number is not found, attempt best-effort exercise by looking up PR number using commit message

Also fixes bug with Github action not being able to deduct the PR-number from commit message with newlines
