### PR TITLE
Throw error if 'schedule' event cannot extract PR number

### DIFF
--- a/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.Tests.ps1
+++ b/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.Tests.ps1
@@ -22,6 +22,23 @@ Describe "Find-RelatedPullRequestNumber" {
         }
     }
 
+    Context 'scheduled event' {
+        It 'should throw error when Sha return null' {
+            Mock Invoke-GithubGetPullRequestFromSha { return $null }
+
+            # Looks up PR-number in Github API
+            { Find-RelatedPullRequestNumber `
+                    -GithubToken $script:GithubToken `
+                    -GithubEvent 'schedule' `
+                    -Sha 'ab34bed2' `
+                    -GithubRepository $script:Repository `
+                    -RefName '/my/refname' `
+                    -CommitMessage 'Fancy commit message'
+            } | Should -Throw -ExpectedMessage "No pull requests found for sha: ab34bed2"
+        }
+    }
+
+
     Context 'pull_request event' {
         It 'should return PR number when SHA returns PR' {
             Mock Invoke-GithubGetPullRequestFromSha { return '{ "title": "some PR title", "number": "4711" }' | ConvertFrom-Json }

--- a/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.ps1
+++ b/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.ps1
@@ -59,20 +59,17 @@ function Find-RelatedPullRequestNumber {
     if ($null -eq $prNumber) {
         # Not so happy path... best effort ahead
         switch ($GithubEvent) {
-            "schedule" {
-                # To be implemented in https://app.zenhub.com/workspaces/the-outlaws-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/team-the-outlaws/2770
 
-                # If $refname is main, look up PR number using SHA
-                # If PR-number is not found, throw error
+            "schedule" {
+                # If PR-number is not found on schedule event, throw error
                 # This will fail scheduled workflows with merge queues enabled.
-                # And that is OK, product team must refactor workflows in CI to
-                # avoid looking up PR numbers in a merge-queue-enabled context
+                # Product team must refactor workflows in CI to
+                # avoid looking up PR numbers in a merge-queue-enabled context using scheduled workflows
+                throw "No pull requests found for sha: $Sha"
             }
             "pull_request" {
-                #
-                if ($null -eq $prNumber) {
-                    throw "No pull requests found for sha: $Sha"
-                }
+                # Given this is a pull_request event, we're currently between a rock and a hard place...
+                throw "No pull requests found for sha: $Sha"
             }
 
             "merge_group" {
@@ -93,7 +90,7 @@ function Find-RelatedPullRequestNumber {
                 # At this point, this is a best effort exercise. You should as a developer in general not rely on looking up PR number
                 # when working on main as you cannot be 100% sure you can always backtrack your commit to a PR when working on main
 
-                # See examples of commit messages in Pester tests'
+                # See examples of commit messages in Pester tests
                 $hasMatch = $CommitMessage -match "\(#(\d+)\)(?!.*\(#\d+\))"
                 if ($hasMatch) {
                     Write-Host $Matches
@@ -101,7 +98,7 @@ function Find-RelatedPullRequestNumber {
                 }
 
                 if ($null -eq $prNumber) {
-                    # If no PR was found, we don't want to fail your workflow, as this will cause i.e. CD dispatch events to fail hard
+                    # If no PR was found, we don't want to fail your workflow, as this will cause  CD dispatch events to fail hard
                     # i.e. when merge queue is enabled on your repository
                     Write-Host "::warning::No pull request number found for commit message '$CommitMessage'"
                 }

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
           minor_version: 25
-          patch_version: 1
+          patch_version: 2
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:


### PR DESCRIPTION
This pull request introduces changes to the `Find-RelatedPullRequestNumber` function and its associated tests to handle scenarios where a scheduled event does not return a pull request number. 

Function modifications:

* [`.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.ps1`](diffhunk://#diff-1d40646c207785e122b71d6d1b9b2e2718f98f05d1e394dabfc2bf5a82cef2dfL62-L76): Updated the `Find-RelatedPullRequestNumber` function to throw an error if no pull request number is found for scheduled events, ensuring that workflows fail appropriately when merge queues are enabled.
