### PR TITLE
Block FluentAssertions v8 and greater

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -22,7 +22,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
-          minor_version: 26
+          minor_version: 27
           patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)

--- a/.github/workflows/dotnet-build-prerelease.yml
+++ b/.github/workflows/dotnet-build-prerelease.yml
@@ -96,10 +96,8 @@ jobs:
           # Check if any version is greater than or equal to 8.0.0
           forbidden_version=$(jq -r '.[] | select(. >= "8.0.0")' fluentassertions-versions.json)
           if [ -n "$forbidden_version" ]; then
-            echo -e "\e[31mForbidden 'FluentAssertions' version $forbidden_version found\e[0m"
+            echo -e "::error title='Forbidden FluentAssertions version detected'::Forbidden 'FluentAssertions' version $forbidden_version found"
             exit 1
-          else
-            echo -e "\e[32mAll 'FluentAssertions' versions are less than 8.0.0\e[0m"
           fi
 
       - name: Build solution

--- a/.github/workflows/dotnet-build-prerelease.yml
+++ b/.github/workflows/dotnet-build-prerelease.yml
@@ -86,6 +86,22 @@ jobs:
       - name: Restore NuGet packages
         run: dotnet restore ${{ inputs.solution_file_path }}
 
+      - name: Block FluentAssertions v8
+        run: |   
+          dotnet list ${{ inputs.solution_file_path }} package --format json > versions.json
+
+          # Find all versions of FluentAssertions
+          jq -r '[.. | objects | select(.topLevelPackages? != null) | .topLevelPackages[] | select(.id == "FluentAssertions") | .requestedVersion]' versions.json > fluentassertions-versions.json
+
+          # Check if any version is greater than or equal to 8.0.0
+          forbidden_version=$(jq -r '.[] | select(. >= "8.0.0")' fluentassertions-versions.json)
+          if [ -n "$forbidden_version" ]; then
+            echo -e "\e[31mForbidden 'FluentAssertions' version $forbidden_version found\e[0m"
+            exit 1
+          else
+            echo -e "\e[32mAll 'FluentAssertions' versions are less than 8.0.0\e[0m"
+          fi
+
       - name: Build solution
         run: |
           # We build the GitHub PR and SHA (last merge commit on PR) into the .NET assembly meta data:

--- a/.github/workflows/dotnet-build-prerelease.yml
+++ b/.github/workflows/dotnet-build-prerelease.yml
@@ -87,7 +87,7 @@ jobs:
         run: dotnet restore ${{ inputs.solution_file_path }}
 
       - name: Block FluentAssertions v8
-        run: |   
+        run: |
           dotnet list ${{ inputs.solution_file_path }} package --format json > versions.json
 
           # Find all versions of FluentAssertions


### PR DESCRIPTION
# Context

FluentAssertions have changed their license and starting from version 8.0.0 all developers that are contributing must have a valid license.

The cost of the license does not match the value received from the package, and it has been decided that we won't upgrade to version 8.

Currently there is no code that is depending on version 8 of FluentAssertions.

# Solution

An additional check is added to the dotnet build steps that will check read all versions of FluentAssertions based on the solution-file. If any version is located the script will terminate with an exitcode of 1.