### PR TITLE
Handle pinned versions of FluentAssertions

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
           minor_version: 27
-          patch_version: 0
+          patch_version: 1
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/dotnet-build-prerelease.yml
+++ b/.github/workflows/dotnet-build-prerelease.yml
@@ -91,7 +91,7 @@ jobs:
           dotnet list ${{ inputs.solution_file_path }} package --format json > versions.json
 
           # Find all versions of FluentAssertions
-          jq -r '[.. | objects | select(.topLevelPackages? != null) | .topLevelPackages[] | select(.id == "FluentAssertions") | .requestedVersion]' versions.json > fluentassertions-versions.json
+          jq -r '[.. | objects | select(.topLevelPackages? != null) | .topLevelPackages[] | select(.id == "FluentAssertions") | .requestedVersion | gsub("\\[|\\]"; "")]' versions.json > fluentassertions-versions.json
 
           # Check if any version is greater than or equal to 8.0.0
           forbidden_version=$(jq -r '.[] | select(. >= "8.0.0")' fluentassertions-versions.json)


### PR DESCRIPTION
This pull request includes updates to the versioning and package handling in the GitHub workflows for creating release tags and building .NET pre-releases. The most important changes involve incrementing the patch version and modifying the `jq` command to handle version strings more accurately.

Versioning updates:

* [`.github/workflows/create-release-tag.yml`](diffhunk://#diff-dd48f7e79b979a8d316ca44ca2cb7466a0b7d2c6acab7e664093e018608f3baeL26-R26): Incremented the `patch_version` from 0 to 1.

Package handling improvements:

* [`.github/workflows/dotnet-build-prerelease.yml`](diffhunk://#diff-abe1564a53f8226e2d0cd3bafd3038d7a77da441280f58e4185bb8c6355446c1L94-R94): Modified the `jq` command to remove square brackets from version strings when extracting `FluentAssertions` versions.