### PR TITLE
Include transitive references to FluentAssertions

### DIFF
--- a/.github/workflows/dotnet-build-prerelease.yml
+++ b/.github/workflows/dotnet-build-prerelease.yml
@@ -94,7 +94,7 @@ jobs:
           forbidden_version=$(jq -r '.. | objects | select(.id == "FluentAssertions" and .resolvedVersion >= "8.0.0") | .resolvedVersion' versions.json)
 
           if [ -n "$forbidden_version" ]; then
-          echo -e "::error title='Forbidden FluentAssertions version detected'::Forbidden 'FluentAssertions' versions $forbidden_version found"
+          echo -e "::error title='Forbidden FluentAssertions version detected'::Forbidden 'FluentAssertions' version $forbidden_version found"
           exit 1
           fi
 

--- a/.github/workflows/dotnet-build-prerelease.yml
+++ b/.github/workflows/dotnet-build-prerelease.yml
@@ -88,16 +88,14 @@ jobs:
 
       - name: Block FluentAssertions v8
         run: |
-          dotnet list ${{ inputs.solution_file_path }} package --format json > versions.json
+          dotnet list ${{ inputs.solution_file_path }} package --format json --include-transitive > versions.json
 
-          # Find all versions of FluentAssertions
-          jq -r '[.. | objects | select(.topLevelPackages? != null) | .topLevelPackages[] | select(.id == "FluentAssertions") | .requestedVersion | gsub("\\[|\\]"; "")]' versions.json > fluentassertions-versions.json
+          # Find all versions of FluentAssertions greater than or equal to 8.0.0
+          forbidden_version=$(jq -r '.. | objects | select(.id == "FluentAssertions" and .resolvedVersion >= "8.0.0") | .resolvedVersion' versions.json)
 
-          # Check if any version is greater than or equal to 8.0.0
-          forbidden_version=$(jq -r '.[] | select(. >= "8.0.0")' fluentassertions-versions.json)
           if [ -n "$forbidden_version" ]; then
-            echo -e "::error title='Forbidden FluentAssertions version detected'::Forbidden 'FluentAssertions' version $forbidden_version found"
-            exit 1
+          echo -e "::error title='Forbidden FluentAssertions version detected'::Forbidden 'FluentAssertions' versions $forbidden_version found"
+          exit 1
           fi
 
       - name: Build solution

--- a/.github/workflows/dotnet-build-prerelease.yml
+++ b/.github/workflows/dotnet-build-prerelease.yml
@@ -94,8 +94,8 @@ jobs:
           forbidden_version=$(jq -r '.. | objects | select(.id == "FluentAssertions" and .resolvedVersion >= "8.0.0") | .resolvedVersion' versions.json)
 
           if [ -n "$forbidden_version" ]; then
-          echo -e "::error title='Forbidden FluentAssertions version detected'::Forbidden 'FluentAssertions' version $forbidden_version found"
-          exit 1
+            echo -e "::error title='Forbidden FluentAssertions version detected'::Forbidden 'FluentAssertions' version $forbidden_version found"
+            exit 1
           fi
 
       - name: Build solution


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/dotnet-build-prerelease.yml` file to enhance the process of blocking specific versions of the `FluentAssertions` package. The most important changes are:

* Included transitive dependencies in the `dotnet list` command to ensure all versions of `FluentAssertions` are captured, not just top-level packages. (`[.github/workflows/dotnet-build-prerelease.ymlL91-R97](diffhunk://#diff-abe1564a53f8226e2d0cd3bafd3038d7a77da441280f58e4185bb8c6355446c1L91-R97)`)
* Simplified the `jq` command to directly find all versions of `FluentAssertions` greater than or equal to `8.0.0` from the `versions.json` file. (`[.github/workflows/dotnet-build-prerelease.ymlL91-R97](diffhunk://#diff-abe1564a53f8226e2d0cd3bafd3038d7a77da441280f58e4185bb8c6355446c1L91-R97)`)