### PR TITLE
find-related-pr-number: replace ' with "

### DIFF
--- a/.github/actions/find-related-pr-number/action.yml
+++ b/.github/actions/find-related-pr-number/action.yml
@@ -41,7 +41,8 @@ runs:
       run: |
         . ${{ github.action_path }}/Find-RelatedPullRequestNumber.ps1
 
-        $commitMessage = '${{ github.event.commits[0].message || '' }}' -Replace "'", ""
+        $commitMessage = "${{ github.event.commits[0].message || '' }}".Replace("'", "")
+        $commitMessage
 
         $prNumber = Find-RelatedPullRequestNumber `
           -GithubToken "${{ github.token }}" `

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
           minor_version: 27
-          patch_version: 2
+          patch_version: 3
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:


### PR DESCRIPTION
This pull request includes a couple of changes to the GitHub Actions configuration files to improve the handling of commit messages and update the release tag version.

Improvements to commit message handling:

* [`.github/actions/find-related-pr-number/action.yml`](diffhunk://#diff-4d7ff2717ec1352d97d3be25ef86a817f8931a76da2333f493aedcd0721dc8c8L44-R45): Modified the way the commit message is processed to use double quotes and the `.Replace` method for better string handling.

Release tag version update:

* [`.github/workflows/create-release-tag.yml`](diffhunk://#diff-dd48f7e79b979a8d316ca44ca2cb7466a0b7d2c6acab7e664093e018608f3baeL26-R26): Updated the `patch_version` from 2 to 3 to reflect a new release.