### PR TITLE
Fixed quoting error in find-related-pr-number

### DIFF
--- a/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.Tests.ps1
+++ b/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.Tests.ps1
@@ -103,6 +103,26 @@ Describe "Find-RelatedPullRequestNumber" {
             @{ CommitMessage = 'Revert "2453: remove deprecated instrumentation key from shared (#2759)" (#2763)'; Expected = '2763' }
             @{ CommitMessage = "Feat: Add new silver schema (#100) $([System.Environment]::NewLine) Co-authored-by: root <root@TEK-8130.localdomain>"; Expected = '100' }
             @{ CommitMessage = 'feat: Added testcommon.etl function to write when files to storage (#84) $([System.Environment]::NewLine) Co-authored-by: root <root@TEK-8130.localdomain>'; Expected = '84' }
+            @{ CommitMessage = "Message with ' (#2678)"; Expected = '2678' }
+            @{ CommitMessage = "Message with '' (#2354)"; Expected = '2354' }
+            @{ CommitMessage = 'Message with " (#9882)'; Expected = '9882' }
+            @{ CommitMessage = 'Message with "" (#5671)'; Expected = '5671' }
+            @{ CommitMessage = 'Message with " and '' (#9821)'; Expected = '9821' }
+            @{ CommitMessage = @"
+This is a multiline commit message with "quotes" and 'single quotes'
+lots of lines
+
+Special characters !"#¤%&/()=?`*'~
+PR numbers that should be ignores: (#123) , (#124) . (#125)
+
+And finally the PR number that should be found: (#9821)
+
+and even more lines to increase the confusion
+
+()
+#
+"@; Expected                 = '9821'
+            }
         ) {
             Mock Invoke-GithubGetPullRequestFromSha { return $null }
 

--- a/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.ps1
+++ b/.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.ps1
@@ -91,10 +91,12 @@ function Find-RelatedPullRequestNumber {
                 # when working on main as you cannot be 100% sure you can always backtrack your commit to a PR when working on main
 
                 # See examples of commit messages in Pester tests
-                $hasMatch = $CommitMessage -match "\(#(\d+)\)(?!.*\(#\d+\))"
-                if ($hasMatch) {
-                    Write-Host $Matches
-                    $prNumber = $Matches[1]
+                $prMatches = [regex]::Matches($CommitMessage, "\(#(\d+)\)")
+
+                if ($prMatches.Count -gt 0) {
+                    Write-Host $prMatches
+                    # Get the last match and the second capture group, which contains the PR number without surrounding (#)
+                    $prNumber = $prMatches[-1].Groups[1].Value
                 }
 
                 if ($null -eq $prNumber) {
@@ -110,7 +112,6 @@ function Find-RelatedPullRequestNumber {
     }
     return $prNumber
 }
-
 
 
 

--- a/.github/actions/find-related-pr-number/action.yml
+++ b/.github/actions/find-related-pr-number/action.yml
@@ -41,8 +41,12 @@ runs:
       run: |
         . ${{ github.action_path }}/Find-RelatedPullRequestNumber.ps1
 
-        $commitMessage = "${{ github.event.commits[0].message || '' }}".Replace("'", "")
-        $commitMessage
+        # github.event.commits[0].message can contain linesbreak single/double qoutes, which can break the templated script.
+        # To avoid this, we use a here-string for the commit message.
+
+        $commitMessage = @"
+          ${{ github.event.commits[0].message || '' }}
+        "@
 
         $prNumber = Find-RelatedPullRequestNumber `
           -GithubToken "${{ github.token }}" `
@@ -50,7 +54,7 @@ runs:
           -Sha "${{ github.event.pull_request.head.sha || github.sha }}" `
           -GithubRepository "${{ github.repository }}" `
           -RefName "${{ github.ref_name }}" `
-          -CommitMessage '$commitMessage'`
+          -CommitMessage $commitMessage
 
         Write-Host "PR number found: $prNumber"
 

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
           minor_version: 27
-          patch_version: 3
+          patch_version: 4
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:


### PR DESCRIPTION
This pull request includes several changes to improve the handling of commit messages and the extraction of related pull request numbers. The most important changes include updating the regex for matching PR numbers, handling multiline and complex commit messages, and adjusting the action workflow to handle commit messages more robustly.

### Improvements to handling commit messages:

* [`.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.Tests.ps1`](diffhunk://#diff-2ab89ce9cf31628068b539fda9ce66cdf40faca1b55ba4d6d36fd2a49fd344bcR106-R125): Added new test cases for commit messages containing various combinations of quotes, special characters, and multiline content.
* [`.github/actions/find-related-pr-number/Find-RelatedPullRequestNumber.ps1`](diffhunk://#diff-1d40646c207785e122b71d6d1b9b2e2718f98f05d1e394dabfc2bf5a82cef2dfL94-R99): Modified the regex to find all PR number matches and select the last one, ensuring more accurate extraction from complex commit messages.

### Adjustments to action workflow:

* [`.github/actions/find-related-pr-number/action.yml`](diffhunk://#diff-4d7ff2717ec1352d97d3be25ef86a817f8931a76da2333f493aedcd0721dc8c8L44-R57): Changed the handling of the `commitMessage` to use a here-string to better manage line breaks and quotes, preventing script breakage.

### Minor version update:

* [`.github/workflows/create-release-tag.yml`](diffhunk://#diff-dd48f7e79b979a8d316ca44ca2cb7466a0b7d2c6acab7e664093e018608f3baeL26-R26): Incremented the patch version from 3 to 4.