### PR TITLE
2843: replace Outlaws with Fusion

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @Energinet-DataHub/TheOutlaws
+*       @Energinet-DataHub/TeamFusion

--- a/.github/actions/send-email/Send-EMail.Tests.ps1
+++ b/.github/actions/send-email/Send-EMail.Tests.ps1
@@ -21,7 +21,7 @@ Describe "When dot-sourcing the script" {
 
     Context "Given Build-ToEMail is called with a single 'to' email address" {
         It "Should build a minified JSON array with one email address" {
-            $teamName = "TheOutlaws"
+            $teamName = "TeamFusion"
             $to = "to@test.com"
 
             $expected = @"
@@ -46,7 +46,7 @@ Describe "When dot-sourcing the script" {
 
     Context "Given Build-ToEMail is called with a list of comma-separated 'to' email addresses" {
         It "Should build a minified JSON array with multiple email addresses sharing the team name value" {
-            $teamName = "TheOutlaws"
+            $teamName = "TeamFusion"
             $to = "one@test.com, two@test.com, three@test.com"
 
             $expected = @"

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
           minor_version: 27
-          patch_version: 6
+          patch_version: 7
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -58,7 +58,7 @@ jobs:
             team_email=${{ vars.email_mandalorian }}
           elif [ ${{ inputs.team_name }} == 'Raccoons' ]; then
             team_email=${{ vars.email_raccoons }}
-          elif [ ${{ inputs.team_name }} == 'TheOutlaws' ]; then
+          elif [ ${{ inputs.team_name }} == 'TeamFusion' ]; then
             team_email=${{ vars.email_teamfusion }}
           elif [ ${{ inputs.team_name }} == 'Volt' ]; then
             team_email=${{ vars.email_volt }}

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -59,7 +59,7 @@ jobs:
           elif [ ${{ inputs.team_name }} == 'Raccoons' ]; then
             team_email=${{ vars.email_raccoons }}
           elif [ ${{ inputs.team_name }} == 'TheOutlaws' ]; then
-            team_email=${{ vars.email_theoutlaws }}
+            team_email=${{ vars.email_teamfusion }}
           elif [ ${{ inputs.team_name }} == 'Volt' ]; then
             team_email=${{ vars.email_volt }}
           elif [ ${{ inputs.team_name}} == 'TeamFrontend' ]; then
@@ -68,7 +68,7 @@ jobs:
             team_email=${{ vars.email_teamesettdeprecated }}
           else
             # Fallback
-            team_email=${{ vars.email_theoutlaws }}
+            team_email=${{ vars.email_teamfusion }}
           fi
 
           echo "::add-mask::$team_email"


### PR DESCRIPTION
This pull request includes changes to update team ownership and email notifications to reflect the new team structure. The most important changes include updating the `CODEOWNERS` file, modifying the patch version in the release workflow, and updating email references in the notify team workflow.

https://app.zenhub.com/workspaces/team-fusion-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/team-the-outlaws/2843

Changes to team ownership:

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L1-R1): Changed ownership from `@Energinet-DataHub/TheOutlaws` to `@Energinet-DataHub/TeamFusion`.

Updates to workflows:

* [`.github/workflows/create-release-tag.yml`](diffhunk://#diff-dd48f7e79b979a8d316ca44ca2cb7466a0b7d2c6acab7e664093e018608f3baeL26-R26): Incremented the `patch_version` from 6 to 7.
* [`.github/workflows/notify-team.yml`](diffhunk://#diff-ba020cb3fcd0c2acc1e7760fce8e653d5d920fde985071afbe9cec6f2a7a21f9L62-R62): Updated email reference for `TheOutlaws` to `TeamFusion` in the conditional statements. [[1]](diffhunk://#diff-ba020cb3fcd0c2acc1e7760fce8e653d5d920fde985071afbe9cec6f2a7a21f9L62-R62) [[2]](diffhunk://#diff-ba020cb3fcd0c2acc1e7760fce8e653d5d920fde985071afbe9cec6f2a7a21f9L71-R71)