### PR TITLE
Replace default value 'ubuntu-22.04' with 'ubuntu-latest'

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
           minor_version: 27
-          patch_version: 1
+          patch_version: 2
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/databricks-build-prerelease.yml
+++ b/.github/workflows/databricks-build-prerelease.yml
@@ -45,7 +45,7 @@ on:
         default: false
       operating_system:
         required: false
-        default: ubuntu-20.04 # Tools for python is not available in arch x64 on 22.04
+        default: ubuntu-latest
         type: string
       prerelease_prefix:
         required: false


### PR DESCRIPTION
# Description

Ubuntu-22.04 will be deprecated with brownouts starting March 1st

Ref: https://github.com/actions/runner-images/issues/11101