### PR TITLE
Enable long filenames

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -22,8 +22,8 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
-          minor_version: 28
-          patch_version: 3
+          minor_version: 29
+          patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -171,6 +171,11 @@ jobs:
       # Overrides settings in 'functionhost.settings.json'
       FunctionAppHostPath: ${{ github.workspace }}\node_modules\azure-functions-core-tools\bin\func.dll
     steps:
+      - name: Enable long filenames
+        shell: pwsh
+        run: |
+          sudo git config --system core.longpaths true
+
       - name: Check out repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Enable long filenames so Process Manager can use this workflow to run tests.