### PR TITLE
Enable long filename on Windows

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -22,7 +22,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
-          minor_version: 29
+          minor_version: 30
           patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -22,8 +22,8 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
-          minor_version: 28
-          patch_version: 3
+          minor_version: 29
+          patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Enable long filenames
         shell: pwsh
         run: |
-          sudo git config --system core.longpaths true
+          git config --system core.longpaths true
 
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -171,6 +171,11 @@ jobs:
       # Overrides settings in 'functionhost.settings.json'
       FunctionAppHostPath: ${{ github.workspace }}\node_modules\azure-functions-core-tools\bin\func.dll
     steps:
+      - name: Enable long filenames
+        shell: pwsh
+        run: |
+          sudo git config --system core.longpaths true
+
       - name: Check out repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Sorry, copy / paste error, should not contain "sudo" when we run on Windows

This time I have tested it here: https://github.com/Energinet-DataHub/opengeh-process-manager/actions/runs/13971448172/job/39114126235?pr=258