### PR TITLE
#2982 - Add pr owner to notify-team.yml

### DIFF
--- a/.github/actions/get-pr-owner/Get-PrOwner.ps1
+++ b/.github/actions/get-pr-owner/Get-PrOwner.ps1
@@ -1,0 +1,50 @@
+# Safety check: PR_LIST must not be empty or null
+if (-not $env:PR_LIST) {
+    Write-Warning "No PR_LIST provided. Skipping PR owner check."
+    "pr_owner=" >> $env:GITHUB_OUTPUT
+    exit 0
+}
+
+# Debug: Log raw PR_LIST to help with diagnostics
+Write-Host "Raw PR_LIST value:"
+Write-Host $env:PR_LIST
+
+$prList = $env:PR_LIST | ConvertFrom-Json
+
+$headers = @{
+    Authorization = "Bearer $env:GH_TOKEN"
+    Accept        = "application/vnd.github+json"
+}
+
+$mergedByList = @()
+
+foreach ($pr in $prList) {
+    $repo = $pr.repo
+    $prNumber = $pr.pr_number
+
+    Write-Host "Checking PR #$prNumber in $repo..."
+
+    try {
+        $prInfo = gh pr view $prNumber --repo $repo --json mergedBy | ConvertFrom-Json
+        $owner = $prInfo.mergedBy.login
+
+        if ($owner) {
+            $mergedByList += "${repo} PR #${prNumber}: ${owner}"
+        } else {
+            Write-Warning "PR #$prNumber in $repo is not merged or missing 'mergedBy'"
+        }
+    } catch {
+        Write-Warning "Failed to fetch PR info for $repo/#$prNumber"
+    }
+}
+
+if ($mergedByList.Count -eq 0) {
+    $summary = "No merged PRs found"
+} else {
+    $summary = $mergedByList -join "<br>"
+}
+
+Write-Host "Merged PR summary:"
+Write-Host $summary
+
+"pr_owner=$summary" >> $env:GITHUB_OUTPUT

--- a/.github/actions/get-pr-owner/action.yml
+++ b/.github/actions/get-pr-owner/action.yml
@@ -1,0 +1,41 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Get PR Owner
+description: Extracts the GitHub username of who merged the PR
+
+inputs:
+  github_token:
+    description: The GitHub token
+    required: true
+  pr_list:
+    description: >
+      A JSON array of PR descriptors like:
+      [{"repo":"Energinet-DataHub/dh3-infrastructure", "pr_number":123}]
+    required: true
+
+outputs:
+  pr_owner:
+    description: GitHub username of the PR author
+    value: ${{ steps.fetch.outputs.pr_owner }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get PR owner
+      id: fetch
+      shell: pwsh
+      run: . ${{ github.action_path }}/Get-PrOwner.ps1
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        PR_LIST: ${{ inputs.pr_list }}

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -22,8 +22,8 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
-          minor_version: 30
-          patch_version: 2
+          minor_version: 31
+          patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Get PR Owner(s)
         id: pr_owner
+        if: ${{ inputs.pr_list != '' }}
         uses: Energinet-DataHub/.github/.github/actions/get-pr-owner@admmu/2982-add-pr-owner-to-notify-team
         with:
           github_token: ${{ steps.generate_token.outputs.token }}
@@ -73,9 +74,9 @@ jobs:
         run: |
           content="<html><body><br>${{ inputs.body }}"
 
-          pr_owner="${{ steps.pr_owner.outputs.pr_owner }}"
-          if [ -n "$pr_owner" ]; then
-            content="$content<br><b>Merged by:</b><br>$pr_owner"
+          
+          if [ -n "${{ steps.pr_owner.outputs.pr_owner || '' }}" ]; then
+            content="$content<br><b>Merged by:</b><br>${{ steps.pr_owner.outputs.pr_owner }}"
           fi
 
           content="$content</body></html>"

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -74,7 +74,6 @@ jobs:
         run: |
           content="<html><body><br>${{ inputs.body }}"
 
-          
           if [ -n "${{ steps.pr_owner.outputs.pr_owner || '' }}" ]; then
             content="$content<br><b>Merged by:</b><br>${{ steps.pr_owner.outputs.pr_owner }}"
           fi

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Get PR Owner(s)
         id: pr_owner
         if: ${{ inputs.pr_list != '' }}
-        uses: Energinet-DataHub/.github/.github/actions/get-pr-owner@admmu/2982-add-pr-owner-to-notify-team
+        uses: ./.github/actions/get-pr-owner
         with:
           github_token: ${{ steps.generate_token.outputs.token }}
           pr_list: ${{ inputs.pr_list }}

--- a/.github/workflows/notify-team.yml
+++ b/.github/workflows/notify-team.yml
@@ -41,11 +41,49 @@ on:
         required: false
         default: ""
         type: string
+      pr_list:
+        description: JSON list of PRs to determine who merged them
+        required: false
+        type: string
 
 jobs:
   notify_team:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate GitHub token
+        id: generate_token
+        uses: Energinet-DataHub/.github/.github/actions/github-create-token@v14
+        with:
+          app_id: ${{ vars.dh3serviceaccount_appid }}
+          private_key: ${{ secrets.dh3serviceaccount_privatekey }}
+
+      - name: Get PR Owner(s)
+        id: pr_owner
+        uses: Energinet-DataHub/.github/.github/actions/get-pr-owner@admmu/2982-add-pr-owner-to-notify-team
+        with:
+          github_token: ${{ steps.generate_token.outputs.token }}
+          pr_list: ${{ inputs.pr_list }}
+
+      - name: Build email content
+        id: email_content
+        shell: bash
+        run: |
+          content="<html><body><br>${{ inputs.body }}"
+
+          pr_owner="${{ steps.pr_owner.outputs.pr_owner }}"
+          if [ -n "$pr_owner" ]; then
+            content="$content<br><b>Merged by:</b><br>$pr_owner"
+          fi
+
+          content="$content</body></html>"
+
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$content" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Determine email
         id: get_email
         shell: bash
@@ -82,4 +120,4 @@ jobs:
           to: ${{ steps.get_email.outputs.team_email }}
           from: ${{ vars.email_internal_sender }}
           subject: ${{ inputs.subject }}
-          content: ${{ inputs.body }}
+          content: ${{ steps.email_content.outputs.content }}


### PR DESCRIPTION
**In this PR:**
- Added PR owners based on the list of PRs (`pr_list`) given from an arbitrary *-deployment.yml job pipeline in their `deployment_failed` step
- Extended notify-team.yml with a new input `pr_list`
- Added new `get-pr-owner` github-action, that makes use of the `pr_list` received and returns github usernames of those that merged the PR(s)
- Supports existing and updated pipelines

**Example runs:**
- The first one showcases when the sauron-cd pipeline has a list of PRs 
- The second one showcases the original job. 
<img width="695" alt="image" src="https://github.com/user-attachments/assets/b8d61ff9-2b82-40e8-bff7-ddaa3160f65c" />
