### PR TITLE
Allow consumer to move nuget cache to workflow directory

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
           minor_version: 31
-          patch_version: 2
+          patch_version: 3
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -162,7 +162,7 @@ jobs:
 
     env:
       ARTIFACT_TEST_PATH: ${{ github.workspace }}\${{ inputs.testproject_name }}
-      NUGET_PACKAGES: ${{ inputs.nuget_cache_path }}
+      NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
 
       # Necessary to manage Azure resources from automated tests
       AZURE_KEYVAULT_URL: ${{ inputs.azure_keyvault_url }}

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -140,6 +140,11 @@ on:
         required: false
         type: string
         default: nuget-${{ inputs.operating_system }}-pr${{ github.event.pull_request.number || '_not_available' }} # PR number is not available in merge_group event (Merge queue)
+      nuget_cache_path:
+        description: Path to nuget packages cachee (default ~/.nuget/packages)
+        required: false
+        type: string
+        default: ~/.nuget/packages
 
 permissions:
   id-token: write
@@ -181,7 +186,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          path: ~/.nuget/packages
+          path: ${{ inputs.nuget_cache_path }}
           key: ${{ inputs.nuget_cache_key_prefix }}-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
             ${{ inputs.nuget_cache_key_prefix }}-

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -162,7 +162,7 @@ jobs:
 
     env:
       ARTIFACT_TEST_PATH: ${{ github.workspace }}\${{ inputs.testproject_name }}
-      NUGET_PACKAGES: ${{ inputs.use_workspace_for_nuget_cache == 'true' && format('{0}/.nuget/packages', github.workspace) || '~/.nuget/packages' }}
+      NUGET_PACKAGES2: ${{ (inputs.use_workspace_for_nuget_cache == 'true' && format('{0}/.nuget/packages', github.workspace)) || '~/.nuget/packages' }}
 
       # Necessary to manage Azure resources from automated tests
       AZURE_KEYVAULT_URL: ${{ inputs.azure_keyvault_url }}
@@ -184,6 +184,15 @@ jobs:
 
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Set NUGET_PACKAGES environment variable
+        shell: pwsh
+        run: |
+          if [ "${{ inputs.use_workspace_for_nuget_cache }}" = "true" ]; then
+            echo "NUGET_PACKAGES=${{ github.workspace }}/.nuget/packages" >> $env:GITHUB_ENV
+          else
+            echo "NUGET_PACKAGES=~/.nuget/packages" >> $env:GITHUB_ENV
+          fi
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -162,7 +162,7 @@ jobs:
 
     env:
       ARTIFACT_TEST_PATH: ${{ github.workspace }}\${{ inputs.testproject_name }}
-      NUGET_PACKAGES: ${{ inputs.use_workspace_for_nuget_cache == 'true' && format('{0}\.nuget\packages', github.workspace) || '~/.nuget/packages' }}
+      NUGET_PACKAGES: ${{ inputs.use_workspace_for_nuget_cache != 'true' && '~/.nuget/packages' || format('{0}\.nuget\packages', github.workspace) }}
 
       # Necessary to manage Azure resources from automated tests
       AZURE_KEYVAULT_URL: ${{ inputs.azure_keyvault_url }}

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -141,7 +141,7 @@ on:
         type: string
         default: nuget-${{ inputs.operating_system }}-pr${{ github.event.pull_request.number || '_not_available' }} # PR number is not available in merge_group event (Merge queue)
       use_workspace_for_nuget_cache:
-        description: If true nuget packages will be placed in ${{ '${{ github.workspace }}/.nuget/packages' }} otherwise ~/.nuget/packages
+        description: If true nuget packages will be placed in github.workspace/.nuget/packages otherwise ~/.nuget/packages
         required: false
         default: false
         type: boolean

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -140,11 +140,11 @@ on:
         required: false
         type: string
         default: nuget-${{ inputs.operating_system }}-pr${{ github.event.pull_request.number || '_not_available' }} # PR number is not available in merge_group event (Merge queue)
-      nuget_cache_path:
-        description: Path to nuget packages cache (default ~/.nuget/packages)
+      use_workspace_for_nuget_cache:
+        description: If true nuget packages will be placed in ${{ github.workspace }}\.nuget\packages otherwise ~/.nuget/packages
         required: false
-        type: string
-        default: ~/.nuget/packages
+        default: false
+        type: boolean
 
 permissions:
   id-token: write
@@ -162,7 +162,7 @@ jobs:
 
     env:
       ARTIFACT_TEST_PATH: ${{ github.workspace }}\${{ inputs.testproject_name }}
-      NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
+      NUGET_PACKAGES: ${{ use_workspace_for_nuget_cache == 'true' && '${{ github.workspace }}\.nuget\packages' || '~/.nuget/packages' }}
 
       # Necessary to manage Azure resources from automated tests
       AZURE_KEYVAULT_URL: ${{ inputs.azure_keyvault_url }}

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -162,6 +162,7 @@ jobs:
 
     env:
       ARTIFACT_TEST_PATH: ${{ github.workspace }}\${{ inputs.testproject_name }}
+      NUGET_PACKAGES: ${{ inputs.nuget_cache_path }}
 
       # Necessary to manage Azure resources from automated tests
       AZURE_KEYVAULT_URL: ${{ inputs.azure_keyvault_url }}

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -188,11 +188,12 @@ jobs:
       - name: Set NUGET_PACKAGES environment variable
         shell: pwsh
         run: |
-          if [ "${{ inputs.use_workspace_for_nuget_cache }}" = "true" ]; then
+          if ("${{ inputs.use_workspace_for_nuget_cache }}" -eq "true") {
             echo "NUGET_PACKAGES=${{ github.workspace }}/.nuget/packages" >> $env:GITHUB_ENV
-          else
+          }
+          else {
             echo "NUGET_PACKAGES=~/.nuget/packages" >> $env:GITHUB_ENV
-          fi
+          }
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -141,7 +141,7 @@ on:
         type: string
         default: nuget-${{ inputs.operating_system }}-pr${{ github.event.pull_request.number || '_not_available' }} # PR number is not available in merge_group event (Merge queue)
       use_workspace_for_nuget_cache:
-        description: If true nuget packages will be placed in ${{ github.workspace }}/.nuget/packages otherwise ~/.nuget/packages
+        description: If true nuget packages will be placed in ${{ '${{ github.workspace }}/.nuget/packages' }} otherwise ~/.nuget/packages
         required: false
         default: false
         type: boolean

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -141,7 +141,7 @@ on:
         type: string
         default: nuget-${{ inputs.operating_system }}-pr${{ github.event.pull_request.number || '_not_available' }} # PR number is not available in merge_group event (Merge queue)
       use_workspace_for_nuget_cache:
-        description: If true nuget packages will be placed in .nuget/packages in the runner workspace otherwise ~/.nuget/packages
+        description: If true packages will be placed in .nuget/packages in the runner workspace
         required: false
         default: false
         type: boolean

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -162,7 +162,7 @@ jobs:
 
     env:
       ARTIFACT_TEST_PATH: ${{ github.workspace }}\${{ inputs.testproject_name }}
-      NUGET_PACKAGES: ${{ use_workspace_for_nuget_cache == 'true' && '${{ github.workspace }}\.nuget\packages' || '~/.nuget/packages' }}
+      NUGET_PACKAGES: ${{ inputs.use_workspace_for_nuget_cache == 'true' && format('{0}\.nuget\packages', github.workspace) || '~/.nuget/packages' }}
 
       # Necessary to manage Azure resources from automated tests
       AZURE_KEYVAULT_URL: ${{ inputs.azure_keyvault_url }}

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -189,10 +189,10 @@ jobs:
         shell: pwsh
         run: |
           if ("${{ inputs.use_workspace_for_nuget_cache }}" -eq "true") {
-            echo "NUGET_PACKAGES=${{ github.workspace }}/.nuget/packages" >> $env:GITHUB_ENV
+            echo "NUGET_PACKAGES=${{ github.workspace }}\.nuget\packages" >> $env:GITHUB_ENV
           }
           else {
-            echo "NUGET_PACKAGES=~/.nuget/packages" >> $env:GITHUB_ENV
+            echo "NUGET_PACKAGES=~\.nuget\packages" >> $env:GITHUB_ENV
           }
 
       - uses: actions/cache@v4

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -187,7 +187,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          path: ${{ inputs.nuget_cache_path }}
+          path: ${{ env.NUGET_PACKAGES }}
           key: ${{ inputs.nuget_cache_key_prefix }}-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
             ${{ inputs.nuget_cache_key_prefix }}-${{ runner.os }}-

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -162,7 +162,6 @@ jobs:
 
     env:
       ARTIFACT_TEST_PATH: ${{ github.workspace }}\${{ inputs.testproject_name }}
-      NUGET_PACKAGES2: ${{ (inputs.use_workspace_for_nuget_cache == 'true' && format('{0}/.nuget/packages', github.workspace)) || '~/.nuget/packages' }}
 
       # Necessary to manage Azure resources from automated tests
       AZURE_KEYVAULT_URL: ${{ inputs.azure_keyvault_url }}

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -141,7 +141,7 @@ on:
         type: string
         default: nuget-${{ inputs.operating_system }}-pr${{ github.event.pull_request.number || '_not_available' }} # PR number is not available in merge_group event (Merge queue)
       use_workspace_for_nuget_cache:
-        description: If true nuget packages will be placed in ${{ github.workspace }}\.nuget\packages otherwise ~/.nuget/packages
+        description: If true nuget packages will be placed in ${{ github.workspace }}/.nuget/packages otherwise ~/.nuget/packages
         required: false
         default: false
         type: boolean
@@ -162,7 +162,7 @@ jobs:
 
     env:
       ARTIFACT_TEST_PATH: ${{ github.workspace }}\${{ inputs.testproject_name }}
-      NUGET_PACKAGES: ${{ inputs.use_workspace_for_nuget_cache != 'true' && '~/.nuget/packages' || format('{0}\.nuget\packages', github.workspace) }}
+      NUGET_PACKAGES: ${{ inputs.use_workspace_for_nuget_cache == 'true' && format('{0}/.nuget/packages', github.workspace) || '~/.nuget/packages' }}
 
       # Necessary to manage Azure resources from automated tests
       AZURE_KEYVAULT_URL: ${{ inputs.azure_keyvault_url }}

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -141,7 +141,7 @@ on:
         type: string
         default: nuget-${{ inputs.operating_system }}-pr${{ github.event.pull_request.number || '_not_available' }} # PR number is not available in merge_group event (Merge queue)
       use_workspace_for_nuget_cache:
-        description: If true nuget packages will be placed in github.workspace/.nuget/packages otherwise ~/.nuget/packages
+        description: If true nuget packages will be placed in .nuget/packages in the runner workspace otherwise ~/.nuget/packages
         required: false
         default: false
         type: boolean

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -192,7 +192,7 @@ jobs:
             echo "NUGET_PACKAGES=${{ github.workspace }}\.nuget\packages" >> $env:GITHUB_ENV
           }
           else {
-            echo "NUGET_PACKAGES=~\.nuget\packages" >> $env:GITHUB_ENV
+            echo "NUGET_PACKAGES=$env:USERPROFILE\.nuget\packages" >> $env:GITHUB_ENV
           }
 
       - uses: actions/cache@v4

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -141,7 +141,7 @@ on:
         type: string
         default: nuget-${{ inputs.operating_system }}-pr${{ github.event.pull_request.number || '_not_available' }} # PR number is not available in merge_group event (Merge queue)
       nuget_cache_path:
-        description: Path to nuget packages cachee (default ~/.nuget/packages)
+        description: Path to nuget packages cache (default ~/.nuget/packages)
         required: false
         type: string
         default: ~/.nuget/packages

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -187,9 +187,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ${{ inputs.nuget_cache_path }}
-          key: ${{ inputs.nuget_cache_key_prefix }}-${{ hashFiles('**/*.csproj') }}
+          key: ${{ inputs.nuget_cache_key_prefix }}-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
-            ${{ inputs.nuget_cache_key_prefix }}-
+            ${{ inputs.nuget_cache_key_prefix }}-${{ runner.os }}-
 
       - name: Set up test environment
         uses: Energinet-Datahub/.github/.github/actions/dotnet-setup-and-tools@v14


### PR DESCRIPTION
This pull request introduces changes to the `.github/workflows/dotnet-postbuild-test-monorepo.yml` file to enhance the configuration of the NuGet package cache. The key changes include adding a new input parameter to control the NuGet package cache location and updating the job steps to use this new parameter.

Enhancements to NuGet package cache configuration:

* Added `use_workspace_for_nuget_cache` input parameter to control whether packages are placed in `.nuget/packages` in the runner workspace or the user profile directory.
* Updated the job steps to set the `NUGET_PACKAGES` environment variable based on the `use_workspace_for_nuget_cache` input parameter.
* Modified the `actions/cache` step to use the `NUGET_PACKAGES` environment variable for the cache path and key.