### PR TITLE
composite action to run the covernator in ci

### DIFF
--- a/.github/actions/python-covernator-generate-files/action.yml
+++ b/.github/actions/python-covernator-generate-files/action.yml
@@ -11,14 +11,14 @@ inputs:
   geh_common_version:
     required: true
     description: The version of geh_common to use. This is used to install the geh_common package from the repository.
-    default: "5.8.11"
+    default: 5.8.11
 
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Checkout
       uses: actions/checkout@v4
-    
+
     - name: Install uv
       uses: astral-sh/setup-uv@v5
 
@@ -43,14 +43,14 @@ runs:
         path: /tmp/covernator_output_folder/${{ inputs.project_name }}/**
 
     - uses: mshick/add-pr-comment@v2
-      name : Add PR-comment with artifact url
+      name: Add PR-comment with artifact url
       if: ${{ steps.covernator-step.outputs.skip != 'true' }}
       with:
         message-id: ${{ inputs.project_name }}
         message: |
           # Covernator (${{ inputs.project_name }})
-          
+
           ✅ Covernator files have been generated (for ${{ inputs.project_name }}) and uploaded as artifacts.
           You can download them [here](${{ steps.artifact-upload-step.outputs.artifact-url }}).
-          
+
           ${{ steps.covernator-step.outputs.stats }}

--- a/.github/actions/python-covernator-generate-files/action.yml
+++ b/.github/actions/python-covernator-generate-files/action.yml
@@ -11,7 +11,7 @@ inputs:
   geh_common_version:
     required: true
     description: The version of geh_common to use. This is used to install the geh_common package from the repository.
-    default: "5.8.9"
+    default: "5.8.11"
 
 runs:
   using: "composite"
@@ -28,7 +28,7 @@ runs:
       run: |
         uv venv
         source .venv/bin/activate
-        uv pip install "geh_common @ git+https://git@github.com/Energinet-DataHub/opengeh-python-packages@achter/covernator_ci_functionality#subdirectory=source/geh_common"
+        uv pip install "geh_common @ git+https://git@github.com/Energinet-DataHub/opengeh-python-packages@geh_common_${{ inputs.geh_common_version }}#subdirectory=source/geh_common"
         cd ${{ inputs.project_directory }}
         python -c "from geh_common.covernator_streamlit import main; main()" \
           -g -o /tmp/covernator_output_folder/${{ inputs.project_name }} -k stats || \

--- a/.github/actions/python-covernator-generate-files/action.yml
+++ b/.github/actions/python-covernator-generate-files/action.yml
@@ -4,8 +4,10 @@ description: Generate covernator files for a Python project and upload them as a
 inputs:
   project_directory:
     required: true
+    description: The directory where the pyproject.toml file is located
   project_name:
     required: true
+    description: The name of the project, which will also be used for the artifact name
 
 runs:
   using: "composite"
@@ -27,24 +29,15 @@ runs:
         name: covernator-files-${{ inputs.project_name }}
         path: /tmp/covernator_output_folder/${{ inputs.project_name }}/**
 
-    - name: Prepare pr-comment message
-      id: pr-comment-message
-      shell: bash
-      run: |
-        if [[ "${{ steps.covernator-step.outputs.skip }}" == "true" ]]; then
-          echo "message=Ⓧ Generation of files was skipped. Check the logs, if this was unintended behavior." >> $GITHUB_OUTPUT
-        else
-          echo "message=✅ Covernator files have been generated (for ${{ inputs.project_directory }}) and uploaded as artifacts.<br>You can download them [here](${{ steps.artifact-upload-step.outputs.artifact-url }})." >> $GITHUB_OUTPUT
-        fi
-
     - uses: mshick/add-pr-comment@v2
       name : Add PR-comment with artifact url
+      if: ${{ steps.covernator-step.outputs.skip != 'true' }}
       with:
         message-id: ${{ inputs.project_name }}
         message: |
           # Covernator (${{ inputs.project_name }})
-
-          ${{ steps.pr-comment-message.outputs.message }}
-
-
-
+          
+          ✅ Covernator files have been generated (for ${{ inputs.project_name }}) and uploaded as artifacts.
+          You can download them [here](${{ steps.artifact-upload-step.outputs.artifact-url }}).
+          
+          ${{ steps.output.stats }}

--- a/.github/actions/python-covernator-generate-files/action.yml
+++ b/.github/actions/python-covernator-generate-files/action.yml
@@ -1,0 +1,50 @@
+name: Generate covernator files
+description: Generate covernator files for a Python project and upload them as artifacts
+
+inputs:
+  project_directory:
+    required: true
+  project_name:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - id: covernator-step
+      name: Run covernator
+      shell: bash
+      run: |
+        uv run --directory ${{ inputs.project_directory }} \
+          python -c "from geh_common.covernator_streamlit import main; main()" \
+          -g -o /tmp/covernator_output_folder/${{ inputs.project_name }} || \
+          { echo 'Covernator not found, please install it first'; echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0; }
+
+    - name: Upload covernator files
+      id: artifact-upload-step
+      if: ${{ steps.covernator-step.outputs.skip != 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: covernator-files-${{ inputs.project_name }}
+        path: /tmp/covernator_output_folder/${{ inputs.project_name }}/**
+
+    - name: Prepare pr-comment message
+      id: pr-comment-message
+      shell: bash
+      run: |
+        if [[ "${{ steps.covernator-step.outputs.skip }}" == "true" ]]; then
+          echo "message=Ⓧ Generation of files was skipped. Check the logs, if this was unintended behavior." >> $GITHUB_OUTPUT
+        else
+          echo "message=✅ Covernator files have been generated (for ${{ inputs.project_directory }}) and uploaded as artifacts.<br>You can download them [here](${{ steps.artifact-upload-step.outputs.artifact-url }})." >> $GITHUB_OUTPUT
+        fi
+
+    - uses: mshick/add-pr-comment@v2
+      name : Add PR-comment with artifact url
+      with:
+        message-id: ${{ inputs.project_name }}
+        message: |
+          # Covernator (${{ inputs.project_name }})
+
+          ${{ steps.pr-comment-message.outputs.message }}
+
+
+

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -22,7 +22,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
-          minor_version: 33
+          minor_version: 34
           patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
           minor_version: 31
-          patch_version: 2
+          patch_version: 3
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/dotnet-postbuild-test-monorepo.yml
+++ b/.github/workflows/dotnet-postbuild-test-monorepo.yml
@@ -140,6 +140,11 @@ on:
         required: false
         type: string
         default: nuget-${{ inputs.operating_system }}-pr${{ github.event.pull_request.number || '_not_available' }} # PR number is not available in merge_group event (Merge queue)
+      use_workspace_for_nuget_cache:
+        description: If true packages will be placed in .nuget/packages in the runner workspace
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   id-token: write
@@ -179,12 +184,22 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set NUGET_PACKAGES environment variable
+        shell: pwsh
+        run: |
+          if ("${{ inputs.use_workspace_for_nuget_cache }}" -eq "true") {
+            echo "NUGET_PACKAGES=${{ github.workspace }}\.nuget\packages" >> $env:GITHUB_ENV
+          }
+          else {
+            echo "NUGET_PACKAGES=$env:USERPROFILE\.nuget\packages" >> $env:GITHUB_ENV
+          }
+
       - uses: actions/cache@v4
         with:
-          path: ~/.nuget/packages
-          key: ${{ inputs.nuget_cache_key_prefix }}-${{ hashFiles('**/*.csproj') }}
+          path: ${{ env.NUGET_PACKAGES }}
+          key: ${{ inputs.nuget_cache_key_prefix }}-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
-            ${{ inputs.nuget_cache_key_prefix }}-
+            ${{ inputs.nuget_cache_key_prefix }}-${{ runner.os }}-
 
       - name: Set up test environment
         uses: Energinet-Datahub/.github/.github/actions/dotnet-setup-and-tools@v14


### PR DESCRIPTION
- new composite action
- geh_common is not required to be installed in the callers repo
- default version only needs to be updated (or overwritten in the caller) if there is a new version to the covernator