### PR TITLE
feat: Enable configuration of max concurrent process

### DIFF
--- a/.github/actions/dotnet-solution-build-and-test/action.yml
+++ b/.github/actions/dotnet-solution-build-and-test/action.yml
@@ -75,7 +75,7 @@ runs:
       id: run_tests
       run: |
         dotnet tool install --tool-path ./temp/reportgenerator dotnet-reportgenerator-globaltool
-        dotnet test ${{ (startsWith(inputs.max_concurrent_processes, 'empty') && '-m') || ('-m:' + inputs.max_concurrent_processes) }} ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
+        dotnet test ${{ (startsWith(inputs.max_concurrent_processes, 'empty') && '-m') || format('-m:{0}', inputs.max_concurrent_processes) }} ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
 
     - name: Publish test report
       uses: EnricoMi/publish-unit-test-result-action/composite@v2

--- a/.github/actions/dotnet-solution-build-and-test/action.yml
+++ b/.github/actions/dotnet-solution-build-and-test/action.yml
@@ -31,6 +31,12 @@ inputs:
   publish_test_report:
     required: false
     default: "false"
+  # Use 'max_concurrent_processes' to limit the number of test processes running in parallel.
+  # Inspired by: https://github.com/nunit/nunit3-vs-adapter/discussions/950#discussioncomment-2073842
+  # Documentation: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test#--maxcpucount
+  max_concurrent_processes:
+    required: false
+    default: "" # Microsoft documentation states this is '1' by default, but it seems to be '' (empty) in practice, which means it will use all available cores. Setting this to '1' will run tests sequentially.
 
 runs:
   using: composite
@@ -69,7 +75,7 @@ runs:
       id: run_tests
       run: |
         dotnet tool install --tool-path ./temp/reportgenerator dotnet-reportgenerator-globaltool
-        dotnet test -m:1 ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
+        dotnet test -m:${{ inputs.max_concurrent_processes }} ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
 
     - name: Publish test report
       uses: EnricoMi/publish-unit-test-result-action/composite@v2

--- a/.github/actions/dotnet-solution-build-and-test/action.yml
+++ b/.github/actions/dotnet-solution-build-and-test/action.yml
@@ -75,7 +75,7 @@ runs:
       id: run_tests
       run: |
         dotnet tool install --tool-path ./temp/reportgenerator dotnet-reportgenerator-globaltool
-        dotnet test ${{ (startsWith(inputs.max_concurrent_processes, 'empty') && '-m') || '-m:inputs.max_concurrent_processes' }} ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
+        dotnet test ${{ !startsWith(inputs.max_concurrent_processes, 'empty') && '-m:inputs.max_concurrent_processes' }} ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
 
     - name: Publish test report
       uses: EnricoMi/publish-unit-test-result-action/composite@v2

--- a/.github/actions/dotnet-solution-build-and-test/action.yml
+++ b/.github/actions/dotnet-solution-build-and-test/action.yml
@@ -75,7 +75,7 @@ runs:
       id: run_tests
       run: |
         dotnet tool install --tool-path ./temp/reportgenerator dotnet-reportgenerator-globaltool
-        dotnet test ${{ (startsWith(inputs.max_concurrent_processes, 'empty') && '-m') || format('-m:{0}', inputs.max_concurrent_processes) }} ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
+        dotnet test ${{ !startsWith(inputs.max_concurrent_processes, 'empty') && format('-m:{0}', inputs.max_concurrent_processes) }} ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
 
     - name: Publish test report
       uses: EnricoMi/publish-unit-test-result-action/composite@v2

--- a/.github/actions/dotnet-solution-build-and-test/action.yml
+++ b/.github/actions/dotnet-solution-build-and-test/action.yml
@@ -36,7 +36,7 @@ inputs:
   # Documentation: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test#--maxcpucount
   max_concurrent_processes:
     required: false
-    default: "empty" # Microsoft documentation states this is '1' by default, but it seems to be '' (empty) in practice, which means it will use all available cores. Setting this to '1' will run tests sequentially spanning assemblies.
+    default: empty # Microsoft documentation states this is '1' by default, but it seems to be '' (empty) in practice, which means it will use all available cores. Setting this to '1' will run tests sequentially spanning assemblies.
 
 runs:
   using: composite

--- a/.github/actions/dotnet-solution-build-and-test/action.yml
+++ b/.github/actions/dotnet-solution-build-and-test/action.yml
@@ -36,7 +36,7 @@ inputs:
   # Documentation: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test#--maxcpucount
   max_concurrent_processes:
     required: false
-    default: "0" # Microsoft documentation states this is '1' by default, but it seems to be '0' in practice, which means it will use all available cores. Setting this to '1' will run tests sequentially.
+    default: "empty" # Microsoft documentation states this is '1' by default, but it seems to be '' (empty) in practice, which means it will use all available cores. Setting this to '1' will run tests sequentially.
 
 runs:
   using: composite
@@ -75,7 +75,7 @@ runs:
       id: run_tests
       run: |
         dotnet tool install --tool-path ./temp/reportgenerator dotnet-reportgenerator-globaltool
-        dotnet test -m:${{ inputs.max_concurrent_processes }} ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
+        dotnet test ${{ (startsWith(inputs.max_concurrent_processes, 'empty') && '-m') || '-m:inputs.max_concurrent_processes' }} ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
 
     - name: Publish test report
       uses: EnricoMi/publish-unit-test-result-action/composite@v2

--- a/.github/actions/dotnet-solution-build-and-test/action.yml
+++ b/.github/actions/dotnet-solution-build-and-test/action.yml
@@ -36,7 +36,7 @@ inputs:
   # Documentation: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test#--maxcpucount
   max_concurrent_processes:
     required: false
-    default: "" # Microsoft documentation states this is '1' by default, but it seems to be '' (empty) in practice, which means it will use all available cores. Setting this to '1' will run tests sequentially.
+    default: "0" # Microsoft documentation states this is '1' by default, but it seems to be '0' in practice, which means it will use all available cores. Setting this to '1' will run tests sequentially.
 
 runs:
   using: composite

--- a/.github/actions/dotnet-solution-build-and-test/action.yml
+++ b/.github/actions/dotnet-solution-build-and-test/action.yml
@@ -75,7 +75,7 @@ runs:
       id: run_tests
       run: |
         dotnet tool install --tool-path ./temp/reportgenerator dotnet-reportgenerator-globaltool
-        dotnet test ${{ !startsWith(inputs.max_concurrent_processes, 'empty') && '-m:' + inputs.max_concurrent_processes }} ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
+        dotnet test ${{ (startsWith(inputs.max_concurrent_processes, 'empty') && '-m') || ('-m:' + inputs.max_concurrent_processes) }} ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
 
     - name: Publish test report
       uses: EnricoMi/publish-unit-test-result-action/composite@v2

--- a/.github/actions/dotnet-solution-build-and-test/action.yml
+++ b/.github/actions/dotnet-solution-build-and-test/action.yml
@@ -75,7 +75,7 @@ runs:
       id: run_tests
       run: |
         dotnet tool install --tool-path ./temp/reportgenerator dotnet-reportgenerator-globaltool
-        dotnet test ${{ !startsWith(inputs.max_concurrent_processes, 'empty') && format('-m:{0}', inputs.max_concurrent_processes) }} ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
+        dotnet test ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} ${{ !startsWith(inputs.max_concurrent_processes, 'empty') && format('-m:{0}', inputs.max_concurrent_processes) }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
 
     - name: Publish test report
       uses: EnricoMi/publish-unit-test-result-action/composite@v2

--- a/.github/actions/dotnet-solution-build-and-test/action.yml
+++ b/.github/actions/dotnet-solution-build-and-test/action.yml
@@ -36,7 +36,7 @@ inputs:
   # Documentation: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test#--maxcpucount
   max_concurrent_processes:
     required: false
-    default: "empty" # Microsoft documentation states this is '1' by default, but it seems to be '' (empty) in practice, which means it will use all available cores. Setting this to '1' will run tests sequentially.
+    default: "empty" # Microsoft documentation states this is '1' by default, but it seems to be '' (empty) in practice, which means it will use all available cores. Setting this to '1' will run tests sequentially spanning assemblies.
 
 runs:
   using: composite

--- a/.github/actions/dotnet-solution-build-and-test/action.yml
+++ b/.github/actions/dotnet-solution-build-and-test/action.yml
@@ -69,7 +69,7 @@ runs:
       id: run_tests
       run: |
         dotnet tool install --tool-path ./temp/reportgenerator dotnet-reportgenerator-globaltool
-        dotnet test ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
+        dotnet test -m:1 ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
 
     - name: Publish test report
       uses: EnricoMi/publish-unit-test-result-action/composite@v2

--- a/.github/actions/dotnet-solution-build-and-test/action.yml
+++ b/.github/actions/dotnet-solution-build-and-test/action.yml
@@ -75,7 +75,7 @@ runs:
       id: run_tests
       run: |
         dotnet tool install --tool-path ./temp/reportgenerator dotnet-reportgenerator-globaltool
-        dotnet test ${{ !startsWith(inputs.max_concurrent_processes, 'empty') && '-m:inputs.max_concurrent_processes' }} ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
+        dotnet test ${{ !startsWith(inputs.max_concurrent_processes, 'empty') && '-m:' + inputs.max_concurrent_processes }} ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
 
     - name: Publish test report
       uses: EnricoMi/publish-unit-test-result-action/composite@v2

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -22,7 +22,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
-          minor_version: 35
+          minor_version: 36
           patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)


### PR DESCRIPTION
Changes in .NET 9 SDK means that we see tests being executed in parallel, even if they are in different assemblies. This causes some CI pipelines to fail (geh-core Messaging). To allow developers to be in control we add the parameter `max_concurrent_processes`.