### PR TITLE
Build python package before test

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,7 +23,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
           minor_version: 38
-          patch_version: 4
+          patch_version: 5
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/python-uv-ci.yml
+++ b/.github/workflows/python-uv-ci.yml
@@ -182,6 +182,28 @@ jobs:
           name: ${{ matrix.inputs.package_name }}
           path: ${{ matrix.inputs.package_path }}
 
+        #
+        # Build and Create Prerelease steps
+        # Note: Conceptually this should be done after the tests, but we want to
+        #       enable manual deployment before waiting for tests to pass to enhance DX.
+        #
+      - name: Build ${{ matrix.inputs.package_name }}
+        if: ${{ steps.changes.outputs.is_changed == 'true' }}
+        run: uv build --wheel --directory ${{ matrix.inputs.package_path }}
+
+      - name: Create prerelease for ${{ matrix.inputs.package_name }}
+        uses: Energinet-DataHub/.github/.github/actions/python-create-prerelease@v14
+        if: ${{ inputs.create_prerelease && steps.changes.outputs.is_changed == 'true' }}
+        with:
+          package_name: ${{ matrix.inputs.package_name }}
+          package_path: ${{ matrix.inputs.package_path }}
+          release_name: ${{ matrix.inputs.release_name }}
+          create_subsystem_release: ${{ inputs.create_subsystem_release }}
+
+        #
+        # Testing steps
+        #
+
       - name: Login to access Azure resources
         uses: azure/login@v2
         if: ${{ steps.changes.outputs.is_changed == 'true' && inputs.azure_spn_id != '' && inputs.azure_tenant_id != '' && inputs.azure_subscription_id != '' }}
@@ -222,16 +244,3 @@ jobs:
           path: ${{ matrix.inputs.package_path }}
           tests_path: ${{ inputs.tests_directory }}
           pytest_addopts: ${{ inputs.pytest_addopts }}
-
-      - name: Build ${{ matrix.inputs.package_name }}
-        if: ${{ steps.changes.outputs.is_changed == 'true' }}
-        run: uv build --wheel --directory ${{ matrix.inputs.package_path }}
-
-      - name: Create prerelease for ${{ matrix.inputs.package_name }}
-        uses: Energinet-DataHub/.github/.github/actions/python-create-prerelease@v14
-        if: ${{ inputs.create_prerelease && steps.changes.outputs.is_changed == 'true' }}
-        with:
-          package_name: ${{ matrix.inputs.package_name }}
-          package_path: ${{ matrix.inputs.package_path }}
-          release_name: ${{ matrix.inputs.release_name }}
-          create_subsystem_release: ${{ inputs.create_subsystem_release }}

--- a/.github/workflows/python-uv-ci.yml
+++ b/.github/workflows/python-uv-ci.yml
@@ -182,11 +182,11 @@ jobs:
           name: ${{ matrix.inputs.package_name }}
           path: ${{ matrix.inputs.package_path }}
 
-        #
-        # Build and Create Prerelease steps
-        # Note: Conceptually this should be done after the tests, but we want to
-        #       enable manual deployment before waiting for tests to pass to enhance DX.
-        #
+      #
+      # Build and Create Prerelease steps
+      # Note: Conceptually this should be done after the tests, but we want to
+      #       enable manual deployment before waiting for tests to pass to enhance DX.
+      #
       - name: Build ${{ matrix.inputs.package_name }}
         if: ${{ steps.changes.outputs.is_changed == 'true' }}
         run: uv build --wheel --directory ${{ matrix.inputs.package_path }}
@@ -200,9 +200,9 @@ jobs:
           release_name: ${{ matrix.inputs.release_name }}
           create_subsystem_release: ${{ inputs.create_subsystem_release }}
 
-        #
-        # Testing steps
-        #
+      #
+      # Testing steps
+      #
 
       - name: Login to access Azure resources
         uses: azure/login@v2

--- a/.github/workflows/python-uv-ci.yml
+++ b/.github/workflows/python-uv-ci.yml
@@ -123,7 +123,7 @@ jobs:
   # Test Packages and Create Prerelease
   #
   ci_test:
-    name: Test Packages and Create Prerelease
+    name: Create Prerelease and Test Packages
     runs-on: ubuntu-24.04
     needs: [ci_matrix]
     # Environment is used when using OIDC to login and access the integration test environment


### PR DESCRIPTION
When there is a need to deploy to dev_00x manually, it's often a waste of time to wait for the long-running unit tests to complete before being able to deploy.

This PR reverts the order of testing and creating the pre-release.

![image](https://github.com/user-attachments/assets/6af38abc-0334-4359-9403-62a5383d0f94)

The PR is tested [here](https://github.com/Energinet-DataHub/geh-settlement-report/pull/226).