### PR TITLE
3128: Markdown link check deprecated, replace

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -97,7 +97,7 @@ jobs:
       # https://github.com/marketplace/actions/markdown-link-check
       - name: Markdown links check
         if: ${{ inputs.skip_markdown_links_check != 'true' }}
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: tcort/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: "yes"
           use-verbose-mode: "yes"


### PR DESCRIPTION
This pull request includes a small update to the `.github/workflows/ci-base.yml` file. The change updates the action used for checking markdown links to a different repository.

* [`.github/workflows/ci-base.yml`](diffhunk://#diff-5e33e311056b2c2aa8e5a0a83263774c849396fa0b5fab47c837d0b653411076L100-R100): Replaced `gaurav-nelson/github-action-markdown-link-check@v1` with `tcort/github-action-markdown-link-check@v1` for the "Markdown links check" job.