### PR TITLE
3239: replace deprecated EnricoMi/composite@v2 action with OS-specific variants

### DIFF
--- a/.github/actions/dotnet-run-tests-with-coverage-and-publish-report/action.yml
+++ b/.github/actions/dotnet-run-tests-with-coverage-and-publish-report/action.yml
@@ -85,7 +85,7 @@ runs:
 
     - name: Publish test report
       if: always()
-      uses: EnricoMi/publish-unit-test-result-action/composite@v2
+      uses: EnricoMi/publish-unit-test-result-action/windows@v2
       with:
         check_name: Test results for ${{ inputs.tests_dll_file_path }}
         comment_title: Test results for ${{ inputs.tests_dll_file_path }}

--- a/.github/actions/dotnet-solution-build-and-test/action.yml
+++ b/.github/actions/dotnet-solution-build-and-test/action.yml
@@ -78,7 +78,7 @@ runs:
         dotnet test ${{ inputs.solution_file_path }} --no-build --configuration ${{ inputs.build_configuration }} ${{ (startsWith(inputs.max_concurrent_processes, 'empty') && '-m') || format('-m:{0}', inputs.max_concurrent_processes) }} --verbosity normal --logger "trx;logfilename=testResults.trx" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --output ${{ github.workspace }}\output
 
     - name: Publish test report
-      uses: EnricoMi/publish-unit-test-result-action/composite@v2
+      uses: EnricoMi/publish-unit-test-result-action/windows@v2
       if: inputs.publish_test_report == 'true' || (failure() && steps.run_tests.conclusion == 'failure' && inputs.publish_test_report == 'true') # Reference_ https://docs.github.com/en/actions/learn-github-actions/expressions#failure-with-conditions
       with:
         check_name: Test results for ${{ inputs.solution_file_path }}

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -25,8 +25,8 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 14
-          minor_version: 39
-          patch_version: 2
+          minor_version: 40
+          patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -323,7 +323,7 @@ jobs:
 
       - name: Publish test report
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action/windows@v2
         with:
           check_name: Test results for ${{ inputs.tests_dll_file_path }}
           comment_title: Test results for ${{ inputs.tests_dll_file_path }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Publish test report
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
         with:
           check_name: Python test results for ${{ inputs.test_report_path }}
           comment_title: Python test results


### PR DESCRIPTION
This pull request updates the `EnricoMi/publish-unit-test-result-action` GitHub Action across multiple workflows to use platform-specific versions (`windows` or `linux`) instead of the generic `composite` version. This change ensures better compatibility and performance for the respective environments.

Platform-specific updates:

* [`.github/actions/dotnet-run-tests-with-coverage-and-publish-report/action.yml`](diffhunk://#diff-75c9b1bc4114c52ce753cf5c68c287a5d0f6ddc997a947fe30847f1956e3336bL88-R88): Changed the action from `composite@v2` to `windows@v2` for publishing test reports.
* [`.github/actions/dotnet-solution-build-and-test/action.yml`](diffhunk://#diff-35091f45345d48be913e8d0fbf984fd7d40f8b9f6250e5e09ea25b80e6bc8b52L81-R81): Updated the action to `windows@v2` for compatibility with the Windows environment in the .NET solution build and test workflow.
* [`.github/workflows/dotnet-postbuild-test.yml`](diffhunk://#diff-6f4585189bcd2806e94557924ff778fb073a1bce2961a7d29429f9d4436a1718L326-R326): Replaced `composite@v2` with `windows@v2` for publishing test reports in the post-build test workflow.
* [`.github/workflows/python-ci.yml`](diffhunk://#diff-e032d65b558ae8a939d517d588bbba6f0bceb4c881720d9b6017aa97fd00cefaL121-R121): Updated the action to `linux@v2` for publishing Python test reports to align with the Linux environment.