### PR TITLE
#2571 - Remove max-2-major-versions logic

### DIFF
--- a/.github/actions/create-release-tag/Create-ReleaseTag.Tests.ps1
+++ b/.github/actions/create-release-tag/Create-ReleaseTag.Tests.ps1
@@ -36,41 +36,6 @@ Describe "Create-ReleaseTag" {
                 "10.0.0","","10.0.0","2023-01-18T07:38:37Z"
 "@ | ConvertFrom-Csv
         }
-
-        Mock Invoke-GithubCodeSearch {
-
-            [GithubCodeSearchResult[]]$mocks = @()
-            $mock1 = [GithubCodeSearchResult]::new()
-            $mock1.Url = "https://github.com/mockOrg/mockRepo"
-            $mock1.Path = "path/to/file"
-            $mock1.Repository = "mockOrg/mockRepo"
-            $mock1.TextMatches = @("uses: mockOrg/mockRepo/some/path/some-action.yml@v10")
-
-            $mock2 = [GithubCodeSearchResult]::new()
-            $mock2.Url = "https://github.com/mockOrg/mockRepo"
-            $mock2.Path = "path/to/file"
-            $mock2.Repository = "mockOrg/mockRepo"
-            $mock2.TextMatches = @("uses: mockOrg/mockRepo/some/path/some-action.yml@v10")
-
-            $mock3 = [GithubCodeSearchResult]::new()
-            $mock3.Url = "https://github.com/mockOrg/mockRepo"
-            $mock3.Path = "path/to/file"
-            $mock3.Repository = "mockOrg/mockRepo"
-            $mock3.TextMatches = @("source = git::https://github.com/AnotherMockOrg/AnotherMockRepo//some/path?ref=v10")
-
-            $mock4 = [GithubCodeSearchResult]::new()
-            $mock4.Url = "https://github.com/mockOrg/mockRepo"
-            $mock4.Path = "path/to/file"
-            $mock4.Repository = "mockOrg/mockRepo"
-            $mock4.TextMatches = @("source = git::https://github.com/AnotherMockOrg/AnotherMockRepo//some/path?ref=v11")
-
-            $mocks += $mock1
-            $mocks += $mock2
-            $mocks += $mock3
-            $mocks += $mock4
-
-            return $mocks
-        }
     }
 
     Context "When two version numbers are compared with Compare-Versions" {
@@ -155,63 +120,6 @@ Describe "Create-ReleaseTag" {
                 -GitHubRepository "mock" `
                 -GitHubBranch "mock" `
                 -GitHubEvent "mock"
-        }
-    }
-
-    Context "Creating a new Major Release" {
-
-        It "Completes successfully if no deprecated versions are found" {
-            Assert-MajorVersionDeprecations -MajorVersion "11" -Repository "mockOrg/mockRepo" -Patterns @("\s*uses:\s*mockOrg/mockRepo(.*)@v(?<version>.*)")
-            Assert-MajorVersionDeprecations -MajorVersion "11" -Repository "AnotherMockOrg/AnotherMockRepo" -Patterns @("AnotherMockOrg/AnotherMockRepo//(.*?)ref=v(?<version>.*)")
-        }
-
-        It "Throws an error if references to deprecated versions are found" {
-            { Assert-MajorVersionDeprecations -MajorVersion "12" -Repository "mockOrg/mockRepo" -Patterns @("\s*uses:\s*mockOrg/mockRepo(.*)yml@v(?<version>.*)") } | Should -Throw
-            { Assert-MajorVersionDeprecations -MajorVersion "12" -Repository "AnotherMockOrg/AnotherMockRepo" -Patterns @("(.*)/AnotherMockOrg/AnotherMockRepo//(.*)ref=v(?<version>.*)") } | Should -Throw
-        }
-    }
-
-    Context "Regular expressions" {
-
-        It "Correctly finds version for .github" {
-
-            # This needs to reflect the value used in .github/.github/workflows/create-release-tag.yml
-            $pattern = "\s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)"
-
-            $tests = @(
-                @{"input" = "uses: Energinet-DataHub/.github/c-d-e@v10"; "expected" = "10" },
-                @{"input" = "uses: Energinet-DataHub/.github/cde/f-g/h@v11"; "expected" = "11" },
-                @{"input" = "uses: Energinet-DataHub/.github/c-d-e.yml@v09   "; "expected" = "09" },
-                @{"input" = "uses: Energinet-DataHub/.github/c-d-e@v101"; "expected" = "101" },
-                @{"input" = "uses: Energinet-DataHub/.github/c-d-e@v101"; "expected" = "101" },
-                @{"input" = "uses: Energinet-DataHub/.github/c-d-e@1.2.3"; "expected" = "1" },
-                @{"input" = "uses: Energinet-DataHub/.github/c-d-e@3.2.1"; "expected" = "3" }
-                @{"input" = "uses: Energinet-DataHub/.github/c-d-e@0003.112.122"; "expected" = "0003" }
-            )
-            $tests | ForEach-Object {
-                $match = [regex]::Match($_.input, $pattern)
-                $match.Success | Should -Be $true
-                $match.Groups["version"] | Should -Be $_.expected
-            }
-        }
-
-        It "Correctly finds version for geh-terraform-modules" {
-            $pattern = "Energinet-DataHub/geh-terraform-modules\.git//(.*?)\?ref=v?(?<version>\d+)"
-
-            $tests = @(
-                @{"input" = "source = `"git::http://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/module.tf?ref=v{0}`""; "expected" = "1" },
-                @{"input" = "source = `"git::http://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/module.tf?ref=v{0}`""; "expected" = "2" },
-                @{"input" = "  source   =   `"git::http://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/module.tf?ref=v{0}`"  "; "expected" = "1" },
-                @{"input" = "source = `"git::http://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/module.tf?ref=v{0}`""; "expected" = "20" },
-                @{"input" = "source = `"git::http://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/module.tf?ref={0}.2.3`""; "expected" = "1" },
-                @{"input" = "source = `"git::http://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/module.tf?ref={0}.2.1`""; "expected" = "3" }
-            )
-            $tests | ForEach-Object {
-                $testString = $_.input -f $_.expected
-                $match = [regex]::Match($testString, $pattern)
-                $match.Success | Should -Be $true
-                $match.Groups["version"] | Should -Be $_.expected
-            }
         }
     }
 }

--- a/.github/actions/create-release-tag/Create-ReleaseTag.ps1
+++ b/.github/actions/create-release-tag/Create-ReleaseTag.ps1
@@ -49,12 +49,7 @@ function Create-ReleaseTag {
         # The value of the GitHub event
         [Parameter(Mandatory)]
         [string]
-        $GitHubEvent,
-
-        # Regex Patterns used to identify references in other projects
-        [Parameter(Mandatory = $false)]
-        [string[]]
-        $UsagePatterns = @()
+        $GitHubEvent
     )
 
     Write-Host "Github event name is: $GitHubEvent"
@@ -67,11 +62,6 @@ function Create-ReleaseTag {
         throw "Error: GH_TOKEN environment variable is not set, see https://cli.github.com/manual/gh_auth_login for details"
     }
 
-    # Validate Version
-    if ($UsagePatterns) {
-        # Check that other projects arent referencing older versions
-        Assert-MajorVersionDeprecations -MajorVersion $MajorVersion -Repository $GitHubRepository -Patterns $UsagePatterns
-    }
     $existingReleases = Get-GithubReleases -GitHubRepository $GitHubRepository
     if ($null -eq $existingReleases) {
         $existingVersions = '0.0.0'
@@ -233,109 +223,3 @@ function Update-VersionTags {
     Write-Host "Creating $Version"
     gh release create $Version --generate-notes --latest --title $Version --target $GithubBranch -R $GitHubRepository
 }
-
-class GithubCodeSearchResult {
-    [string]$Url
-    [string]$Repository
-    [string]$Path
-    [string[]]$TextMatches
-
-    [string]ToString() {
-        return ("Link: {0}`nRepository: {1}`nPath: {2}`nContext:`n{3}" -f $this.Url, $this.Repository, $this.Path, ($this.TextMatches -join "`n-`n"))
-    }
-}
-
-<#
-    .SYNOPSIS
-    Helper function to perform a Github code search
-
-    .DESCRIPTION
-    Searches github code api for references to a specific repository. Returns GithubCodeSearchResult
-#>
-function Invoke-GithubCodeSearch {
-    param(
-        #The Sub-path in the repository for relevant files. By default only files in .github/ are relevant
-        [Parameter(Mandatory)]
-        [string]$Search,
-
-        #Limit search to a specific github organization. By default this is always Energinet-DataHub
-        [Parameter(Mandatory = $false)]
-        [string]$Organization
-    )
-
-    [GithubCodeSearchResult[]]$searchResults = @()
-
-    [string]$json = gh api -H "Accept: application/vnd.github.text-match+json" `
-        -H "X-GitHub-Api-Version: 2022-11-28" `
-        "/search/code?q=org:$Organization%20$Search"
-
-    if ($null -eq $json) {
-        throw "Unable to search github code api for version deprecations"
-    }
-
-    foreach ($item in ($json | ConvertFrom-Json).Items) {
-        $result = [GithubCodeSearchResult]::new()
-        $result.Path = $item.path
-        $result.Repository = $item.repository.full_name
-        $result.Url = $item.html_url
-        $result.TextMatches = $item.text_matches.fragment
-        $searchResults += $result
-    }
-
-    return $searchResults
-}
-<#
-    .SYNOPSIS
-    Identifies and prevents further execution if deprecated major version are found
-
-    .DESCRIPTION
-    Runs through a github code api search with specific patterns and throws an exception in case specific references to deprecated versions are found
-#>
-function Assert-MajorVersionDeprecations {
-    param(
-        #Major Version
-        [Parameter(Mandatory)]
-        [string]$MajorVersion,
-
-        #The Repository being referenced
-        [Parameter(Mandatory)]
-        [string]$Repository,
-
-        #Patterns to identify version references. Must contain a named (?<version>) group to identify version number.
-        [Parameter(Mandatory)]
-        [string[]]$Patterns,
-
-        #Patterns to identify version references. Must contain a named (?<version>) group to identify version number.
-        # Note: This value needs to be kept in sync with the automated cleanup script in dh3-automation
-        # https://github.com/Energinet-DataHub/dh3-automation/blob/main/source/github-repository/Remove-DeprecatedReleases.ps1
-        [Parameter(Mandatory = $false)]
-        [int]$MajorVersionsToKeep = 2
-    )
-
-    [string]$Organization = $Repository -split "/" | Select-Object -First 1
-    [GithubCodeSearchResult[]] $searchResults = Invoke-GithubCodeSearch -Organization $Organization -Search $Repository
-
-    if ($searchResults.Count -eq 0) {
-        return $true
-    }
-
-    [int]$UnsupportedVersion = $MajorVersion - $MajorVersionsToKeep
-
-    # Filter all search results and find lines referencing deprecated version tags
-    [GithubCodeSearchResult[]]$filteredResults = $searchResults | Where-Object {
-        $searchResult = $_
-        $matchFound = $false
-        $Patterns | ForEach-Object {
-            $match = [regex]::Match($searchResult.TextMatches, $_)
-            $matchFound = $matchFound -or ($match.Success -and [int]$match.Groups["version"].Value -le $UnsupportedVersion)
-        }
-        return $matchFound
-    }
-
-    if ($filteredResults.Count -gt 0) {
-        $filteredResults | % { Write-Host "--- Version deprecation:`n$($_.ToString())" }
-
-        throw "Cannot Update Major Version to $MajorVersion. Found deprecated references. Need to update depending projects first."
-    }
-}
-

--- a/.github/actions/create-release-tag/action.yml
+++ b/.github/actions/create-release-tag/action.yml
@@ -31,9 +31,6 @@ inputs:
     description: "Branch on which tags will be created. Default: main"
     required: false
     default: main
-  usage_patterns:
-    description: "A list of regular expressions (separated by a whitespace) used to identify major version references in other repositories. Must contain a named group: (?<version>\\d+)"
-    required: false
 
 runs:
   using: composite
@@ -46,7 +43,6 @@ runs:
         $patch = ${{ inputs.patch_version }}
         $repo = "${{ inputs.repository_path }}"
         $targetBranch = "${{ inputs.target_branch }}"
-        $usage_patterns = "${{ inputs.usage_patterns }}" -split " "
         $eventName = "${{ github.event_name }}"
 
         . ${{ github.action_path }}/Create-ReleaseTag.ps1
@@ -57,4 +53,3 @@ runs:
         -GithubRepository $repo `
         -GithubBranch $targetBranch `
         -GithubEvent $eventName `
-        -UsagePatterns $usage_patterns


### PR DESCRIPTION
This pull request removes functionality related to identifying and validating deprecated major version references in other repositories. The changes simplify the codebase by removing associated methods, parameters, and tests.

### Removal of deprecated version validation functionality:

* Removed the `Assert-MajorVersionDeprecations` and `Invoke-GithubCodeSearch` functions, along with the `GithubCodeSearchResult` class, from `Create-ReleaseTag.ps1`. These were previously used to identify and handle deprecated major version references.
* Removed the `UsagePatterns` parameter from the `Create-ReleaseTag` function in `Create-ReleaseTag.ps1` and its corresponding logic for validating references to older versions. [[1]](diffhunk://#diff-ae946b80c66958cdf8136c591606b841a85d88760816b3a94e037d0e13d7b540L52-R52) [[2]](diffhunk://#diff-ae946b80c66958cdf8136c591606b841a85d88760816b3a94e037d0e13d7b540L70-L74)
* Deleted the `usage_patterns` input from `action.yml` and removed its usage in the action's run script. [[1]](diffhunk://#diff-1e6aa6b47cbf3bc36cca5dcf9c17316b7c23248726d44e5ceaf4d979a841245eL34-L36) [[2]](diffhunk://#diff-1e6aa6b47cbf3bc36cca5dcf9c17316b7c23248726d44e5ceaf4d979a841245eL49) [[3]](diffhunk://#diff-1e6aa6b47cbf3bc36cca5dcf9c17316b7c23248726d44e5ceaf4d979a841245eL60)

### Test cleanup:

* Removed tests related to deprecated version validation, including contexts for "Creating a new Major Release" and "Regular expressions" in `Create-ReleaseTag.Tests.ps1`.
* Deleted mocked data for `Invoke-GithubCodeSearch` in `Create-ReleaseTag.Tests.ps1`.