### PR TITLE
Move install tools to after detect changes

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -25,8 +25,8 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 15
-          minor_version: 0
-          patch_version: 2
+          minor_version: 1
+          patch_version: 0
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/python-uv-ci.yml
+++ b/.github/workflows/python-uv-ci.yml
@@ -138,9 +138,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install tools
-        uses: Energinet-DataHub/.github/.github/actions/asdf-install-tools@v14
-
       - name: Check if ${{ matrix.inputs.package_name }} has changed
         uses: dorny/paths-filter@v3
         id: changes
@@ -150,6 +147,10 @@ jobs:
               - ${{ matrix.inputs.package_path }}/**
             is_src_changed:
               - ${{ matrix.inputs.package_path }}/${{ inputs.package_source_code_directory }}/**
+
+      - name: Install tools
+        if: ${{ steps.changes.outputs.is_src_changed == 'true' }}
+        uses: Energinet-DataHub/.github/.github/actions/asdf-install-tools@v14
 
       - name: Check Version
         if: ${{ steps.changes.outputs.is_src_changed == 'true' && inputs.create_versioned_release }}


### PR DESCRIPTION
This pull request updates workflow configurations for release tagging and Python CI jobs. The main changes include updating the release version numbers and optimizing when the tool installation step runs in the Python CI workflow.

Release version update:

* Updated the `minor_version` to `1` and `patch_version` to `0` in `.github/workflows/create-release-tag.yml` to reflect a new release version.

Python CI workflow optimization:

* Moved the `Install tools` step in `.github/workflows/python-uv-ci.yml` to run only when there are changes detected in the source code, reducing unnecessary installations and improving workflow efficiency. [[1]](diffhunk://#diff-c8cb6b741ee765bcb3f53e0051e40310f72f8809c7ae01a022875c91a93685cfL141-L143) [[2]](diffhunk://#diff-c8cb6b741ee765bcb3f53e0051e40310f72f8809c7ae01a022875c91a93685cfR151-R154)