### PR TITLE
fix: Change order in dotnet postbuild test

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -26,7 +26,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 15
           minor_version: 1
-          patch_version: 0
+          patch_version: 1
           repository_path: Energinet-DataHub/.github
           usage_patterns: \s*uses:\s*Energinet-DataHub/\.github(.*)@v?(?<version>\d+)
         env:

--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -272,14 +272,6 @@ jobs:
           attempt_limit: ${{ inputs.download_attempt_limit }}
           attempt_delay: 15000
 
-      - name: Login to use Azure resources from automated tests
-        if: ${{ inputs.run_integration_tests == true }}
-        uses: azure/login@v2
-        with:
-          client-id: ${{ inputs.azure_integrationtest_spn_id }}
-          tenant-id: ${{ inputs.azure_integrationtest_tenant_id }}
-          subscription-id: ${{ inputs.azure_integrationtest_subscription_id }}
-
       - name: Unzip dotnet-tests-outputs.zip
         shell: pwsh
         run: |
@@ -291,6 +283,14 @@ jobs:
           key: ${{ inputs.nuget_cache_key_prefix }}-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
             ${{ inputs.nuget_cache_key_prefix }}-
+
+      - name: Login to use Azure resources from automated tests
+        if: ${{ inputs.run_integration_tests == true }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ inputs.azure_integrationtest_spn_id }}
+          tenant-id: ${{ inputs.azure_integrationtest_tenant_id }}
+          subscription-id: ${{ inputs.azure_integrationtest_subscription_id }}
 
       # To ensure code coverage tooling is available in bin folders, teams must use 'publish' on test assemblies
       # See https://github.com/coverlet-coverage/coverlet/issues/521#issuecomment-522429394

--- a/.github/workflows/dotnet-postbuild-test.yml
+++ b/.github/workflows/dotnet-postbuild-test.yml
@@ -262,14 +262,6 @@ jobs:
               Exit 1
             }
 
-      - name: Login to use Azure resources from automated tests
-        if: ${{ inputs.run_integration_tests == true }}
-        uses: azure/login@v2
-        with:
-          client-id: ${{ inputs.azure_integrationtest_spn_id }}
-          tenant-id: ${{ inputs.azure_integrationtest_tenant_id }}
-          subscription-id: ${{ inputs.azure_integrationtest_subscription_id }}
-
       - name: Wait for dotnet-tests artifact to be ready for download
         uses: Wandalen/wretry.action@v1
         with:
@@ -279,6 +271,14 @@ jobs:
             path: ${{ env.ARTIFACTS_PATH }}
           attempt_limit: ${{ inputs.download_attempt_limit }}
           attempt_delay: 15000
+
+      - name: Login to use Azure resources from automated tests
+        if: ${{ inputs.run_integration_tests == true }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ inputs.azure_integrationtest_spn_id }}
+          tenant-id: ${{ inputs.azure_integrationtest_tenant_id }}
+          subscription-id: ${{ inputs.azure_integrationtest_subscription_id }}
 
       - name: Unzip dotnet-tests-outputs.zip
         shell: pwsh


### PR DESCRIPTION
In EDI subsystem we often experience that Authorization/Token is timed out. 

I suspect that this is because the login to azure resources is before waiting for dotnet-tests artifact to be ready for download. 

The `Wait for dotnet-tests artifact to be ready for download` often takes around 5-6 minutes before it is done.

**note**

Tested in EDI: https://github.com/Energinet-DataHub/opengeh-edi/pull/1836

All tests were OK in first try. It usually fails because of some authorization